### PR TITLE
Fix NullReferenceException in hearing loss calculation while using jump pack

### DIFF
--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/HealthCondition_Initializer.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/HealthCondition_Initializer.cs
@@ -19,7 +19,12 @@ public static class HealthCondition_Initializer
         BodyPartDefOf.Head.hitPoints = 20;
 
         // inject hearing loss hooks into all gun defs
-        IEnumerable<ThingDef> guns = DefDatabase<ThingDef>.AllDefsListForReading.Where(def => def.Verbs?.Any(verb => verb.range > 0) is true);
+        IEnumerable<ThingDef> guns = DefDatabase<ThingDef>.AllDefsListForReading
+            .Where(def => def is 
+            { 
+                weaponClasses.Count: > 0, 
+                Verbs.Count: > 0 
+            } && def.Verbs.Any(verb => verb.range > 0));
         foreach (ThingDef def in guns)
         {
             def.comps ??= [];

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/HearingLoss/HearingLossComp.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/HearingLoss/HearingLossComp.cs
@@ -81,6 +81,11 @@ public class HearingLossComp : ThingComp
         {
             return;
         }
+        // exit early if the map is null
+        if (shooter.Map is null)
+        {
+            return;
+        }
         // apply hearing damage to the shooter
         ApplyHearingDamage(shooter, shooter);
         // apply hearing damage to nearby pawns if enabled (excluding the shooter)


### PR DESCRIPTION
fixes #24:
- only apply hearing loss comp to weapons
- add null check to hearing loss comp