### PR TITLE
Costs rebalancing and deathless/breathless integration, also concussion rework

### DIFF
--- a/Defs/HediffDefs/Hediffs_Anesthetics.xml
+++ b/Defs/HediffDefs/Hediffs_Anesthetics.xml
@@ -51,17 +51,19 @@
       <li>
         <label>trace exposure</label>
         <minSeverity>0</minSeverity>
-        <painFactor>0.95</painFactor>
+        <painFactor>0.8</painFactor>
       </li>
       <li>
         <label>therapeutic dose</label>
         <minSeverity>0.1</minSeverity>
         <forgetMemoryThoughtMtbDays>4</forgetMemoryThoughtMtbDays>
+        <painFactor>0.5</painFactor>
       </li>
       <li>
         <label>maximum safe dose</label>
         <minSeverity>0.2</minSeverity>
         <forgetMemoryThoughtMtbDays>2</forgetMemoryThoughtMtbDays>
+        <painFactor>0.1</painFactor>
       </li>
       <li>
         <label>minor overdose</label>
@@ -190,19 +192,19 @@
       <li>
         <label>trace exposure</label>
         <minSeverity>0</minSeverity>
-        <painFactor>0.95</painFactor>
+        <painFactor>0.9</painFactor>
         <vomitMtbDays>2</vomitMtbDays>
       </li>
       <li>
         <label>therapeutic dose</label>
         <minSeverity>0.1</minSeverity>
-        <painFactor>0.9</painFactor>
+        <painFactor>0.8</painFactor>
         <vomitMtbDays>1</vomitMtbDays>
       </li>
       <li>
         <label>maximum safe dose</label>
         <minSeverity>0.2</minSeverity>
-        <painFactor>0.85</painFactor>
+        <painFactor>0.5</painFactor>
         <vomitMtbDays>0.5</vomitMtbDays>
       </li>
       <li>
@@ -226,7 +228,7 @@
         <capMods>
           <li>
             <capacity>Consciousness</capacity>
-            <setMax>0.01</setMax>
+            <setMax>0.1</setMax>
           </li>
         </capMods>
       </li>
@@ -242,4 +244,76 @@
       </li>
     </stages>
   </HediffDef>
+
+  <ChemicalDef>
+    <defName>MI_Ketamine_Chemical</defName>
+    <label>ketamine</label>
+    <addictionHediff>MI_KetamineAddiction</addictionHediff>
+    <toleranceHediff>MI_KetamineTolerance</toleranceHediff>
+    <geneOverdoseChanceFactorResist>0.5</geneOverdoseChanceFactorResist>
+    <geneOverdoseChanceFactorImmune>0</geneOverdoseChanceFactorImmune>
+  </ChemicalDef>
+
+  <NeedDef ParentName="DrugAddictionNeedBase">
+    <defName>MI_Ketamine_Chemical_Need</defName>
+    <needClass>Need_Chemical</needClass>
+    <label>ketamine</label>
+    <description>Because of a ketamine addiction, this person needs to regularly consume the drug to avoid withdrawal symptoms.</description>
+    <fallPerDay>0.2</fallPerDay>
+    <listPriority>25</listPriority>
+  </NeedDef>
+
+  <HediffDef ParentName="DrugToleranceBase">
+    <defName>MI_KetamineTolerance</defName>
+    <label>ketamine tolerance</label>
+    <description>A built-up tolerance to ketamine. The more severe this tolerance is, the more ketamine it takes to get the same effect.</description>
+    <comps>
+      <li Class="HediffCompProperties_SeverityPerDay">
+        <severityPerDay>-0.05</severityPerDay>
+      </li>
+      <li Class="HediffCompProperties_DrugEffectFactor">
+        <chemical>MI_Ketamine_Chemical</chemical>
+      </li>
+    </comps>
+  </HediffDef>
+
+  <HediffDef ParentName="AddictionBase">
+    <defName>MI_KetamineAddiction</defName>
+    <label>ketamine addiction</label>
+    <description>A psychological dependence on ketamine. Chronic use has altered neurotransmitter systems involved in mood and cognition, creating a powerful craving for the dissociative state it provides.
+\nWithout ketamine, severe psychological withdrawal symptoms will manifest. However, prolonged abstinence will allow brain chemistry to gradually return to normal, resolving the addiction.</description>
+    <hediffClass>Hediff_Addiction</hediffClass>
+    <chemicalNeed>MI_Ketamine_Chemical_Need</chemicalNeed>
+    <comps>
+      <li Class="HediffCompProperties_SeverityPerDay">
+        <severityPerDay>-0.05</severityPerDay>
+        <showDaysToRecover>true</showDaysToRecover>
+      </li>
+    </comps>
+    <stages>
+      <li>
+      </li>
+      <li>
+        <label>withdrawal</label>
+		    <socialFightChanceFactor>2.0</socialFightChanceFactor>
+        <statOffsets>
+					<MentalBreakThreshold>5</MentalBreakThreshold>
+          <GlobalLearningFactor>0.6</GlobalLearningFactor>
+				</statOffsets>	
+        <mentalStateGivers>        
+          <li>
+            <mentalState>Binging_DrugMajor</mentalState>
+            <mtbDays>30</mtbDays>
+          </li>
+          <li>
+            <mentalState>Wander_Psychotic</mentalState>   <!-- Dissociative wandering -->
+            <mtbDays>10</mtbDays>
+          </li>
+        </mentalStateGivers>
+      </li>
+    </stages>
+  </HediffDef>
+
+
+
 </Defs>

--- a/Defs/HediffDefs/Hediffs_CardiacArrest.xml
+++ b/Defs/HediffDefs/Hediffs_CardiacArrest.xml
@@ -201,7 +201,7 @@
         <capMods>
           <li>
             <capacity>Consciousness</capacity>
-            <setMax>0.01</setMax>
+            <setMax>0.1</setMax>
           </li>
         </capMods>
       </li>

--- a/Defs/HediffDefs/Hediffs_Choking.xml
+++ b/Defs/HediffDefs/Hediffs_Choking.xml
@@ -4,7 +4,6 @@
     <defName>ChokingOnBlood</defName>
     <label>choking on blood</label>
     <description>Blood from traumatic injuries being aspirated into the airways triggers coughing and causes suffocation. The bleeding must be stopped and the airways cleared to prevent death. If the patient is conscious, they may be able to cough up the blood on their own and clear the airway. Otherwise, the airways must be cleared using a specialized airway suction device or by compressing the chest using CPR to expel the blood and restore breathing.</description>
-    <lethalSeverity>1</lethalSeverity>
     <defaultLabelColor>(255, 102, 102)</defaultLabelColor>
     <tendable>false</tendable>
     <comps>
@@ -47,7 +46,7 @@
         <lifeThreatening>true</lifeThreatening>
       </li>
       <li>
-        <minSeverity>0.250</minSeverity>
+        <minSeverity>0.30</minSeverity>
         <label>moderate</label>
         <lifeThreatening>true</lifeThreatening>
         <capMods>
@@ -66,10 +65,6 @@
             <capacity>Breathing</capacity>
             <setMax>0.55</setMax>
           </li>
-          <li>
-            <capacity>Moving</capacity>
-            <offset>-0.350</offset>
-          </li>
         </capMods>
       </li>
       <li>
@@ -79,11 +74,18 @@
         <capMods>
           <li>
             <capacity>Breathing</capacity>
-            <setMax>0.4</setMax>
+            <setMax>0.35</setMax>
           </li>
+        </capMods>
+      </li>
+      <li>
+        <minSeverity>0.70</minSeverity>
+        <label>very severe</label>
+        <lifeThreatening>true</lifeThreatening>
+        <capMods>
           <li>
-            <capacity>Moving</capacity>
-            <offset>-0.450</offset>
+            <capacity>Breathing</capacity>
+            <setMax>0.3</setMax>
           </li>
         </capMods>
       </li>
@@ -94,11 +96,51 @@
         <capMods>
           <li>
             <capacity>Breathing</capacity>
+            <setMax>0.2</setMax>
+          </li>
+        </capMods>
+      </li>
+      <li>
+        <minSeverity>0.85</minSeverity>
+        <label>extreme</label>
+        <lifeThreatening>true</lifeThreatening>
+        <capMods>
+          <li>
+            <capacity>Breathing</capacity>
+            <setMax>0.15</setMax>
+          </li>
+        </capMods>
+      </li>
+      <li>
+        <minSeverity>0.90</minSeverity>
+        <label>extreme</label>
+        <lifeThreatening>true</lifeThreatening>
+        <capMods>
+          <li>
+            <capacity>Breathing</capacity>
             <setMax>0.1</setMax>
           </li>
+        </capMods>
+      </li>
+      <li>
+        <minSeverity>0.95</minSeverity>
+        <label>extreme</label>
+        <lifeThreatening>true</lifeThreatening>
+        <capMods>
           <li>
-            <capacity>Moving</capacity>
-            <offset>-0.850</offset>
+            <capacity>Breathing</capacity>
+            <setMax>0.05</setMax>
+          </li>
+        </capMods>
+      </li>
+      <li>
+        <minSeverity>1.0</minSeverity>
+        <label>lethal</label>
+        <lifeThreatening>true</lifeThreatening>
+        <capMods>
+          <li>
+            <capacity>Breathing</capacity>
+            <setMax>0.0</setMax>
           </li>
         </capMods>
       </li>

--- a/Defs/HediffDefs/Hediffs_Hemodilution.xml
+++ b/Defs/HediffDefs/Hediffs_Hemodilution.xml
@@ -142,7 +142,7 @@
           <li>
             <!-- light-headedness -->
             <capacity>Consciousness</capacity>
-            <setMax>0.9</setMax>
+            <offset>-0.2</offset>
           </li>
         </capMods>
       </li>
@@ -152,7 +152,7 @@
         <capMods>
           <li>
             <capacity>Consciousness</capacity>
-            <setMax>0.75</setMax>
+            <offset>-0.4</offset>
           </li>
         </capMods>
       </li>
@@ -163,7 +163,8 @@
         <capMods>
           <li>
             <capacity>Consciousness</capacity>
-            <setMax>0.4</setMax>
+            <setMax>0.8</setMax>
+            <offset>-0.5</offset>
           </li>
         </capMods>
       </li>
@@ -174,7 +175,7 @@
         <capMods>
           <li>
             <capacity>Consciousness</capacity>
-            <setMax>0.01</setMax>
+            <setMax>0.2</setMax>
           </li>
         </capMods>
       </li>

--- a/Defs/HediffDefs/Hediffs_Morphine.xml
+++ b/Defs/HediffDefs/Hediffs_Morphine.xml
@@ -101,7 +101,7 @@
       <li>
         <label>trace exposure</label>
         <minSeverity>0</minSeverity>
-        <painFactor>0.8</painFactor>
+        <painFactor>0.6</painFactor>
         <!-- ref: https://www.ncbi.nlm.nih.gov/books/NBK526115/ -->
         <vomitMtbDays>2</vomitMtbDays>
         <capMods>
@@ -119,7 +119,7 @@
         <capMods>
           <li>
             <capacity>Consciousness</capacity>
-            <offset>-0.25</offset>
+            <offset>-0.2</offset>
           </li>
           <li>
             <capacity>Breathing</capacity>
@@ -135,7 +135,7 @@
         <capMods>
           <li>
             <capacity>Consciousness</capacity>
-            <offset>-0.4</offset>
+            <offset>-0.3</offset>
           </li>
           <li>
             <capacity>Breathing</capacity>
@@ -146,12 +146,12 @@
       <li>
         <label>minor overdose</label>
         <minSeverity>0.4</minSeverity>
-        <painFactor>0.2</painFactor>
+        <painFactor>0.1</painFactor>
         <vomitMtbDays>0.25</vomitMtbDays>
         <capMods>
           <li>
             <capacity>Consciousness</capacity>
-            <setMax>0.25</setMax>
+            <offset>-0.4</offset>
           </li>
           <li>
             <capacity>Breathing</capacity>
@@ -165,7 +165,7 @@
         <capMods>
           <li>
             <capacity>Consciousness</capacity>
-            <setMax>0.01</setMax>
+            <setMax>0.1</setMax>
           </li>
         </capMods>
       </li>
@@ -181,4 +181,72 @@
       </li>
     </stages>
   </HediffDef>
+
+  <ChemicalDef>
+    <defName>MI_Morphine_Chemical</defName>
+    <label>morphine</label>
+    <addictionHediff>MI_MorphineAddiction</addictionHediff>
+    <toleranceHediff>MI_MorphineTolerance</toleranceHediff>
+    <onGeneratedAddictedToleranceChance>0.8</onGeneratedAddictedToleranceChance>
+    <geneToleranceBuildupFactorResist>0.5</geneToleranceBuildupFactorResist>
+    <geneToleranceBuildupFactorImmune>0</geneToleranceBuildupFactorImmune>
+    <geneOverdoseChanceFactorResist>0.5</geneOverdoseChanceFactorResist>
+    <geneOverdoseChanceFactorImmune>0</geneOverdoseChanceFactorImmune>
+  </ChemicalDef>
+
+  <NeedDef ParentName="DrugAddictionNeedBase">
+    <defName>MI_Morphine_Chemical_Need</defName>
+    <needClass>Need_Chemical</needClass>
+    <label>morphine</label>
+    <description>Because of a morphine addiction, this person needs to regularly consume the drug to avoid withdrawal symptoms.</description>
+    <fallPerDay>0.25</fallPerDay>
+    <listPriority>25</listPriority>
+  </NeedDef>
+
+  <HediffDef ParentName="DrugToleranceBase">
+    <defName>MI_MorphineTolerance</defName>
+    <label>morphine tolerance</label>
+    <description>A built-up tolerance to morphine. The more severe this tolerance is, the more morphine it takes to get the same effect.</description>
+    <comps>
+      <li Class="HediffCompProperties_SeverityPerDay">
+        <severityPerDay>-0.05</severityPerDay>
+      </li>
+      <li Class="HediffCompProperties_DrugEffectFactor">
+        <chemical>MI_Morphine_Chemical</chemical>
+      </li>
+    </comps>
+  </HediffDef>
+
+  <HediffDef ParentName="AddictionBase">
+    <defName>MI_MorphineAddiction</defName>
+    <label>morphine addiction</label>
+    <description>A chemical addiction to morphine. Long-term use of morphine has caused neurological adaptations at the cellular level, so the brain can no longer function properly without the drug.
+\nWithout regular doses of morphine, withdrawal symptoms will begin. However, extended abstinence will force the brain to adapt back to its normal state, resolving the addiction.</description>
+    <hediffClass>Hediff_Addiction</hediffClass>
+    <chemicalNeed>MI_Morphine_Chemical_Need</chemicalNeed>
+    <comps>
+      <li Class="HediffCompProperties_SeverityPerDay">
+        <severityPerDay>-0.0333</severityPerDay>
+        <showDaysToRecover>true</showDaysToRecover>
+      </li>
+    </comps>
+    <stages>
+      <li>
+      </li>
+      <li>
+        <label>withdrawal</label>
+		    <socialFightChanceFactor>2.0</socialFightChanceFactor>
+        <statOffsets>
+					<MentalBreakThreshold>10</MentalBreakThreshold>
+				</statOffsets>	
+        <mentalStateGivers>        
+          <li>
+            <mentalState>Binging_DrugMajor</mentalState>
+            <mtbDays>50</mtbDays>
+          </li>
+        </mentalStateGivers>
+      </li>
+    </stages>
+  </HediffDef>
+
 </Defs>

--- a/Defs/RecipeDefs/Things/Medicine_Bandage.xml
+++ b/Defs/RecipeDefs/Things/Medicine_Bandage.xml
@@ -5,7 +5,7 @@
     <label>make bandage</label>
     <description>Make a bandage.</description>
     <jobString>Making a bandage.</jobString>
-    <workAmount>150</workAmount>
+    <workAmount>50</workAmount>
     <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
     <effectWorking>Cook</effectWorking>
     <soundWorking>Recipe_CookMeal</soundWorking>
@@ -43,7 +43,7 @@
     <label>make bandages x5</label>
     <description>Make 5 bandages.</description>
     <jobString>Making 5 bandages.</jobString>
-    <workAmount>750</workAmount>
+    <workAmount>250</workAmount>
     <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
     <effectWorking>Cook</effectWorking>
     <soundWorking>Recipe_CookMeal</soundWorking>

--- a/Defs/RecipeDefs/Things/Medicine_HemostaticAgent.xml
+++ b/Defs/RecipeDefs/Things/Medicine_HemostaticAgent.xml
@@ -5,7 +5,7 @@
     <label>make hemostatic agent x5</label>
     <description>Make 5 hemostatic agents.</description>
     <jobString>Making 5 hemostatic agents.</jobString>
-    <workAmount>900</workAmount>
+    <workAmount>750</workAmount>
     <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
     <effectWorking>Cook</effectWorking>
     <soundWorking>Recipe_CookMeal</soundWorking>

--- a/Defs/RecipeDefs/Things/Medicine_SalineBag.xml
+++ b/Defs/RecipeDefs/Things/Medicine_SalineBag.xml
@@ -20,7 +20,7 @@
             <li>StoneBlocks</li>
           </categories>
         </filter>
-        <count>10</count>
+        <count>5</count>
       </li>
       <li MayRequire="Dubwise.DubsBadHygiene">
         <filter>
@@ -64,7 +64,7 @@
             <li>StoneBlocks</li>
           </categories>
         </filter>
-        <count>2</count>
+        <count>1</count>
       </li>
       <li MayRequire="Dubwise.DubsBadHygiene">
         <filter>

--- a/Defs/ThingDefs/Medicine/Medicine_Bandage.xml
+++ b/Defs/ThingDefs/Medicine/Medicine_Bandage.xml
@@ -19,7 +19,7 @@
       <Bulk MayRequire="CETeam.CombatExtended">0.05</Bulk>
       <MarketValue>5</MarketValue>
       <MaxHitPoints>5</MaxHitPoints>
-      <WorkToMake>150</WorkToMake>
+      <WorkToMake>50</WorkToMake>
     </statBases>
     <drawGUIOverlay>true</drawGUIOverlay>
     <modExtensions>

--- a/Defs/ThingDefs/Medicine/Medicine_Drugs.xml
+++ b/Defs/ThingDefs/Medicine/Medicine_Drugs.xml
@@ -21,8 +21,12 @@
     <techLevel>Industrial</techLevel>
     <ingestible>
       <drugCategory>Medical</drugCategory>
+      <baseIngestTicks>60</baseIngestTicks>
       <ingestCommandString>Use {0}</ingestCommandString>
       <ingestReportString>using {0}.</ingestReportString>
+      <useEatingSpeedStat>false</useEatingSpeedStat>
+      <chairSearchRadius>0</chairSearchRadius>
+      <foodType>Processed, Fluid</foodType>
     </ingestible>
     <comps>
       <li Class="CompProperties_Drug">
@@ -54,6 +58,9 @@
         </outcomeDoers>
       </li>
     </modExtensions>
+    <statBases>
+      <MarketValue>20</MarketValue>
+    </statBases>
     <ingestible>
       <outcomeDoers>
         <li Class="IngestionOutcomeDoer_GiveHediff">
@@ -77,9 +84,10 @@
       <displayPriority>1500</displayPriority>
     </recipeMaker>
     <costList>
-      <Chemfuel>4</Chemfuel>
-      <Yayo>1</Yayo>
-      <Flake>1</Flake>
+      <Chemfuel>1</Chemfuel>
+      <Neutroamine>1</Neutroamine>
+      <PsychoidLeaves>2</PsychoidLeaves>
+      <Steel>1</Steel>
     </costList>
     <comps>
       <li Class="CompProperties_Drug">
@@ -92,6 +100,10 @@
     <defName>Ketamine</defName>
     <label>ketamine autoinjector</label>
     <description>A pre-loaded autoinjector containing a strong dissociative anesthetic. Effective in emergency field care for patients in severe pain or to induce rapid sedation in patients resisting treatment.</description>
+    <descriptionHyperlinks>
+      <HediffDef>KetamineBuildup</HediffDef>
+      <HediffDef>MI_KetamineAddiction</HediffDef>
+    </descriptionHyperlinks>
     <graphicData>
       <texPath>Thing/Ketamine</texPath>
     </graphicData>
@@ -123,7 +135,13 @@
         </outcomeDoers>
       </li>
     </modExtensions>
+    <statBases>
+      <MarketValue>40</MarketValue>
+    </statBases>
     <ingestible>
+      <joyKind>Chemical</joyKind>
+      <joy>0.45</joy>
+      <drugCategory>Hard</drugCategory>
       <outcomeDoers>
         <li Class="IngestionOutcomeDoer_GiveHediff">
           <hediffDef>Anesthetic</hediffDef>
@@ -132,7 +150,15 @@
         <li Class="IngestionOutcomeDoer_GiveHediff">
           <hediffDef>KetamineBuildup</hediffDef>
           <severity>0.35</severity>
+          <divideByBodySize>true</divideByBodySize>
+          <toleranceChemical>MI_Ketamine_Chemical</toleranceChemical>
         </li>
+        <li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>MI_KetamineTolerance</hediffDef>
+					<severity>0.1</severity>
+					<divideByBodySize>true</divideByBodySize>
+					<toleranceChemical>MI_Ketamine_Chemical</toleranceChemical>
+				</li>
       </outcomeDoers>
     </ingestible>
     <recipeMaker>
@@ -150,13 +176,19 @@
       <displayPriority>1500</displayPriority>
     </recipeMaker>
     <costList>
-      <Yayo>1</Yayo>
-      <SmokeleafLeaves>4</SmokeleafLeaves>
       <Chemfuel>1</Chemfuel>
+      <Neutroamine>3</Neutroamine>
+      <Steel>1</Steel>
     </costList>
     <comps>
       <li Class="CompProperties_Drug">
+        <chemical>MI_Ketamine_Chemical</chemical>
+				<addictiveness>0.05</addictiveness>
+				<existingAddictionSeverityOffset>0.2</existingAddictionSeverityOffset>
+				<needLevelOffset>1</needLevelOffset>
+				<listOrder>20</listOrder>
         <overdoseSeverityOffset>0.05~0.09</overdoseSeverityOffset>
+        <largeOverdoseChance>0.001</largeOverdoseChance>
       </li>
     </comps>
   </ThingDef>
@@ -214,6 +246,13 @@
         </outcomeDoers>
       </li>
     </modExtensions>
+    <statBases>
+      <WorkToMake>200</WorkToMake>
+      <MarketValue>10</MarketValue>
+      <Mass>0.2</Mass>
+      <Bulk MayRequire="CETeam.CombatExtended">0.3</Bulk>
+      <Flammability>0.9</Flammability>
+    </statBases>
     <ingestible>
       <outcomeDoers>
         <li Class="IngestionOutcomeDoer_GiveHediff">
@@ -228,6 +267,7 @@
       </outcomeDoers>
       <ingestCommandString>Inhale chloroform</ingestCommandString>
       <ingestReportString>inhaling chloroform.</ingestReportString>
+      <baseIngestTicks>360</baseIngestTicks>
     </ingestible>
     <recipeMaker>
       <researchPrerequisites>
@@ -244,8 +284,8 @@
       <displayPriority>1500</displayPriority>
     </recipeMaker>
     <costList>
-      <SmokeleafLeaves>4</SmokeleafLeaves>
-      <Chemfuel>1</Chemfuel>
+      <Chemfuel>2</Chemfuel>
+      <Cloth>1</Cloth>
     </costList>
     <comps>
       <li Class="CompProperties_Drug">
@@ -258,6 +298,11 @@
     <defName>Morphine</defName>
     <label>morphine autoinjector</label>
     <description>A morphine autoinjector is a spring-loaded syringe used to deliver a controlled dose of morphine, an opioid pain medication, directly into the bloodstream. Once injected, morphine rapidly suppresses pain but risks respiratory depression and impaired resuscitation if used during severe blood loss or cardiac arrest. Best reserved for controlled environments or after bleeding is stabilized. Should not be mixed with other CNS depressants like alcohol.</description>
+    <descriptionHyperlinks>
+      <HediffDef>MorphineBuildup</HediffDef>
+      <HediffDef>MI_MorphineAddiction</HediffDef>
+      <HediffDef>MI_MorphineTolerance</HediffDef>
+    </descriptionHyperlinks>
     <graphicData>
       <texPath>Thing/Morphine</texPath>
     </graphicData>
@@ -271,12 +316,26 @@
         </outcomeDoers>
       </li>
     </modExtensions>
+    <statBases>
+      <MarketValue>11</MarketValue>
+    </statBases>
     <ingestible>
+      <drugCategory>Hard</drugCategory>
+      <joyKind>Chemical</joyKind>
+      <joy>0.60</joy>
       <outcomeDoers>
         <li Class="IngestionOutcomeDoer_GiveHediff">
           <hediffDef>MorphineBuildup</hediffDef>
           <severity>0.35</severity>
+          <toleranceChemical>MI_Morphine_Chemical</toleranceChemical>
         </li>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>MI_MorphineTolerance</hediffDef>
+          <toleranceChemical>MI_Morphine_Chemical</toleranceChemical>
+					<severity>0.2</severity>
+					<divideByBodySize>true</divideByBodySize>
+          <multiplyByGeneToleranceFactors>true</multiplyByGeneToleranceFactors>
+				</li>
       </outcomeDoers>
     </ingestible>
     <recipeMaker>
@@ -294,13 +353,19 @@
       <displayPriority>1500</displayPriority>
     </recipeMaker>
     <costList>
-      <Flake>1</Flake>
-      <SmokeleafLeaves>4</SmokeleafLeaves>
-      <Chemfuel>1</Chemfuel>
+      <SmokeleafLeaves>3</SmokeleafLeaves>
+      <Steel>1</Steel>
     </costList>
     <comps>
       <li Class="CompProperties_Drug">
-        <overdoseSeverityOffset>0.08~0.14</overdoseSeverityOffset>
+				<chemical>MI_Morphine_Chemical</chemical>
+				<addictiveness>0.99</addictiveness>
+				<existingAddictionSeverityOffset>0.2</existingAddictionSeverityOffset>
+				<needLevelOffset>1</needLevelOffset>
+        <isCombatEnhancingDrug>true</isCombatEnhancingDrug>
+				<listOrder>20</listOrder>
+        <overdoseSeverityOffset>0.1~0.3</overdoseSeverityOffset>
+        <largeOverdoseChance>0.01</largeOverdoseChance>
       </li>
     </comps>
   </ThingDef>

--- a/Defs/ThingDefs/Medicine/Medicine_HemostaticAgent.xml
+++ b/Defs/ThingDefs/Medicine/Medicine_HemostaticAgent.xml
@@ -16,9 +16,9 @@
     <statBases>
       <Mass>0.03</Mass>
       <Bulk MayRequire="CETeam.CombatExtended">0.03</Bulk>
-      <MarketValue>5</MarketValue>
+      <MarketValue>20</MarketValue>
       <MaxHitPoints>5</MaxHitPoints>
-      <WorkToMake>100</WorkToMake>
+      <WorkToMake>150</WorkToMake>
     </statBases>
     <drawGUIOverlay>true</drawGUIOverlay>
     <modExtensions>

--- a/Defs/ThingDefs/Medicine/Medicine_Transfusions.xml
+++ b/Defs/ThingDefs/Medicine/Medicine_Transfusions.xml
@@ -31,8 +31,8 @@
     </modExtensions>
     <statBases>
       <Mass>0.75</Mass>
-      <Bulk MayRequire="CETeam.CombatExtended">1.5</Bulk>
-      <MarketValue>50</MarketValue>
+      <Bulk MayRequire="CETeam.CombatExtended">0.5</Bulk>
+      <MarketValue>20</MarketValue>
       <MaxHitPoints>32</MaxHitPoints>
     </statBases>
     <thingCategories>
@@ -130,8 +130,8 @@
     </modExtensions>
     <statBases>
       <Mass>0.25</Mass>
-      <Bulk MayRequire="CETeam.CombatExtended">0.5</Bulk>
-      <MarketValue>50</MarketValue>
+      <Bulk MayRequire="CETeam.CombatExtended">0.25</Bulk>
+      <MarketValue>5</MarketValue>
       <MaxHitPoints>32</MaxHitPoints>
     </statBases>
     <thingCategories>

--- a/Defs/ThoughtDefs/ThoughtDefs_Ketamine.xml
+++ b/Defs/ThoughtDefs/ThoughtDefs_Ketamine.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
   <ThoughtDef>
-    <defName>MorphineHigh</defName>
+    <defName>KetamineHigh</defName>
     <workerClass>ThoughtWorker_Hediff</workerClass>
-    <hediff>MorphineBuildup</hediff>
+    <hediff>KetamineBuildup</hediff>
     <validWhileDespawned>true</validWhileDespawned>
     <developmentalStageFilter>Child, Adult</developmentalStageFilter>
     <stages>
@@ -15,15 +15,15 @@
       <li>
         <label>warm pudding limbs</label>
         <description>Yeah... that's the stuff. My limbs feel like warm pudding.</description>
-        <baseMoodEffect>10</baseMoodEffect>
+        <baseMoodEffect>5</baseMoodEffect>
       </li>
       <li>
-        <label>pure euphoria</label>
+        <label>ketamine relaxation</label>
         <description>Wheeeeeeeeeeeeeeeeeeeeeeee.</description>
-        <baseMoodEffect>25</baseMoodEffect>
+        <baseMoodEffect>5</baseMoodEffect>
       </li>
       <li>
-        <label>drifting away</label>
+        <label>terrible hallucinations</label>
         <description>The pain left, but something stranger came to visit. Whoa... my hands are filled with teeth. Why are they chewing? Huh? ... Oh, the floor just whispered my name and asked me to lie down forever. It's getting hard to breathe... the air is thick like soup, like I'm choking on alphabet letters. Why is gravity apologizing to me? I think I should go to sleep now...</description>
         <baseMoodEffect>-15</baseMoodEffect>
       </li>
@@ -31,20 +31,21 @@
   </ThoughtDef>
 
   <ThoughtDef>
-      <defName>MI_MorphineWithdrawal</defName>
+      <defName>MI_KetamineWithdrawal</defName>
       <workerClass>ThoughtWorker_Hediff</workerClass>
-      <hediff>MI_MorphineAddiction</hediff>
+      <hediff>MI_KetamineAddiction</hediff>
       <validWhileDespawned>true</validWhileDespawned>
       <stages>
         <li>
           <visible>false</visible>
         </li>
         <li>
-          <label>morphine withdrawal</label>
+          <label>ketamine withdrawal</label>
           <description>I really need to go get some relief...</description>
-          <baseMoodEffect>-25</baseMoodEffect>
+          <baseMoodEffect>-15</baseMoodEffect>
         </li>
       </stages>
     </ThoughtDef>
+
 
 </Defs>

--- a/Defs/ThoughtDefs/ThoughtDefs_Paralysis.xml
+++ b/Defs/ThoughtDefs/ThoughtDefs_Paralysis.xml
@@ -10,17 +10,17 @@
       <li>
         <label>numbness and tingling</label>
         <description>I can't feel parts of my body the way I used to. It's so strange... like I'm half-disconnected from myself.</description>
-        <baseMoodEffect>-2</baseMoodEffect>
+        <baseMoodEffect>-5</baseMoodEffect>
       </li>
       <li>
         <label>limited mobility</label>
         <description>Moving is difficult and frustrating. I feel trapped in my own body, and even simple tasks are exhausting.</description>
-        <baseMoodEffect>-5</baseMoodEffect>
+        <baseMoodEffect>-10</baseMoodEffect>
       </li>
       <li>
         <label>complete paralysis</label>
         <description>I can't move. My body won't respond, no matter how hard I try. I'm like a vegetable - locked inside myself. Nothing will ever be the same again.</description>
-        <baseMoodEffect>-10</baseMoodEffect>
+        <baseMoodEffect>-20</baseMoodEffect>
       </li>
     </stages>
   </ThoughtDef>

--- a/Patches/Patch_BloodLoss.xml
+++ b/Patches/Patch_BloodLoss.xml
@@ -90,8 +90,8 @@
             <hediffMakerProps Class="MoreInjuries.HealthConditions.Secondary.Handlers.HediffMakers.HediffMakerProperties_SingleHediff">
               <hediffMakerDef>
                 <hediffDef>BrainDamage_Hypoxia</hediffDef>
-                <minSeverity>0.01</minSeverity>
-                <maxSeverity>0.5</maxSeverity>
+                <minSeverity>0.00</minSeverity>
+                <maxSeverity>0.00</maxSeverity>
                 <allowMultiple>true</allowMultiple>
                 <allowDuplicate>false</allowDuplicate>
               </hediffMakerDef>

--- a/Source/MoreInjuries/MoreInjuries/Extensions/HediffSetExtensions.cs
+++ b/Source/MoreInjuries/MoreInjuries/Extensions/HediffSetExtensions.cs
@@ -70,4 +70,13 @@ public static class HediffSetExtensions
             }
         }
     }
+
+
+    public static bool IsArtificialPart(this HediffSet hediffSet, BodyPartRecord part)
+    {
+        // Check if any hediff on this part is an artificial part (bionics)
+        return hediffSet.hediffs.Any(hediff => 
+            hediff.Part == part && 
+            hediff.def.addedPartProps is not null);
+    }
 }

--- a/Source/MoreInjuries/MoreInjuries/Extensions/PawnExtensions.cs
+++ b/Source/MoreInjuries/MoreInjuries/Extensions/PawnExtensions.cs
@@ -38,7 +38,7 @@ public static class PawnExtensions
         }
 
         // Check for Odyssey "Breathless" gene (breathes differently, immune to oxygen deficiency)
-        GeneDef breathlessGene = DefDatabase<GeneDef>.GetNamedSilentFail("Breathless");
+        GeneDef breathlessGene = DefDatabase<GeneDef>.GetNamedSilentFail("VacuumResistance_Total");
         if (breathlessGene != null && pawn.genes.HasActiveGene(breathlessGene))
         {
             return true;

--- a/Source/MoreInjuries/MoreInjuries/Extensions/PawnExtensions.cs
+++ b/Source/MoreInjuries/MoreInjuries/Extensions/PawnExtensions.cs
@@ -19,4 +19,31 @@ public static class PawnExtensions
         }
         return defaultValue;
     }
+
+    // Check if pawn has a gene that grants oxygen-deficiency immunity
+    // Supports: Biotech "Deathless" gene and Odyssey "Breathless" gene
+    public static bool HasOxygenDeficiencyImmunity(this Pawn pawn)
+    {
+        // Check if pawn has genes (Biotech/Odyssey feature)
+        if (!ModsConfig.BiotechActive || pawn.genes is null)
+        {
+            return false;
+        }
+
+        // Check for Biotech "Deathless" gene (grants immunity to suffocation and hypoxia-related conditions)
+        GeneDef deathlessGene = DefDatabase<GeneDef>.GetNamedSilentFail("Deathless");
+        if (deathlessGene != null && pawn.genes.HasActiveGene(deathlessGene))
+        {
+            return true;
+        }
+
+        // Check for Odyssey "Breathless" gene (breathes differently, immune to oxygen deficiency)
+        GeneDef breathlessGene = DefDatabase<GeneDef>.GetNamedSilentFail("Breathless");
+        if (breathlessGene != null && pawn.genes.HasActiveGene(breathlessGene))
+        {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/CardiacArrest/HediffComp_CardiacArrest.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/CardiacArrest/HediffComp_CardiacArrest.cs
@@ -1,4 +1,5 @@
-﻿using RimWorld;
+﻿using MoreInjuries.Extensions;
+using RimWorld;
 using Verse;
 
 namespace MoreInjuries.HealthConditions.CardiacArrest;
@@ -7,11 +8,24 @@ public class HediffComp_CardiacArrest : HediffComp
 {
     public override void CompPostPostAdd(DamageInfo? dinfo)
     {
-        if (ModLister.BiotechInstalled && parent.pawn.health.hediffSet.HasHediff(HediffDefOf.Deathrest))
+        Pawn pawn = parent.pawn;
+
+        // Remove if pawn has oxygen deficiency immunity (Deathless/Breathless genes)
+        if (pawn.HasOxygenDeficiencyImmunity())
+        {
+            Logger.LogDebug($"Removing cardiac arrest from {pawn.Name} due to oxygen-deficiency immunity gene");
+            pawn.health.RemoveHediff(parent);
+            return;
+        }
+
+        // Remove if pawn is deathresting (Biotech integration)
+        if (ModLister.BiotechInstalled && pawn.health.hediffSet.HasHediff(HediffDefOf.Deathrest))
         {
             // immediate self-removal if the pawn is deathresting
-            parent.pawn.health.RemoveHediff(parent);
+            pawn.health.RemoveHediff(parent);
+            return;
         }
+
         base.CompPostPostAdd(dinfo);
     }
 }

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/HeadInjury/Concussions/ConcussionExplosionsWorker.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/HeadInjury/Concussions/ConcussionExplosionsWorker.cs
@@ -1,16 +1,106 @@
 ﻿using MoreInjuries.Defs.WellKnown;
+using RimWorld;
 using UnityEngine;
 using Verse;
 
 namespace MoreInjuries.HealthConditions.HeadInjury.Concussions;
 
+#region Concussion Severity Configuration
+// ============================================================================
+// CONCUSSION SEVERITY CONFIGURATION - Adjust these values to balance gameplay
+// ============================================================================
+
+/// <summary>
+/// Body part damage multipliers for concussion generation.
+/// Higher values = more concussion damage from the same hit.
+/// These represent the "importance" of each brain region:
+/// - Head (outer protection): Lowest multiplier, represents deflected/reduced damage
+/// - Skull (bone): Medium multiplier, represents structural damage transmission
+/// - Brain (core): Highest multiplier, represents direct neural tissue damage
+/// </summary>
+internal static class ConcussionBodyPartMultipliers
+{
+    /// <summary>Head - Outer head region, provides some protection. Least severe concussion source.</summary>
+    public const float Head = 0.5f;
+    
+    /// <summary>Skull - Bone structure, medium severity. Impacts can transmit through bone.</summary>
+    public const float Skull = 1.5f;
+    
+    /// <summary>Brain - Direct neural tissue damage, most severe concussion source.</summary>
+    public const float Brain = 3.0f;
+    
+    /// <summary>Default multiplier for unknown/unrecognized head-related body parts.</summary>
+    public const float Default = 1.0f;
+}
+
+/// <summary>
+/// Damage type-to-concussion percentage mapping.
+/// Represents how much concussion % is generated per 1 point of actual received damage.
+/// Higher values = more concussion per damage.
+/// 
+/// These percentages represent the traumatic effect of different damage types:
+/// - Blunt force (Blunt, Bomb, Thermobaric): High concussion (20-25%)
+/// - Penetrating (Bullet, Arrow, Stab): Moderate concussion (5-10%)
+/// - Special effects (Crush, Nerve): Varies by mechanism
+/// - Other: Conservative default value for unrecognized mod damage types
+/// </summary>
+internal static class ConcussionDamageTypePercentages
+{
+    /// <summary>Blunt force trauma - HIGH concussion. Whole-head impact.</summary>
+    public const float Blunt = 0.20f; // 20% concussion per 1 damage
+    
+    /// <summary>Explosive damage - HIGHEST concussion. Blast pressure and fragmentation.</summary>
+    public const float Bomb = 0.25f; // 25% concussion per 1 damage
+    
+    /// <summary>Thermobaric/fuel-air explosives - VERY HIGH concussion. Extreme blast pressure.</summary>
+    public const float Thermobaric = 0.25f; // 25% concussion per 1 damage
+    
+    /// <summary>Bullet impact - LOW concussion. Focused penetrating wound, less whole-head trauma.</summary>
+    public const float Bullet = 0.05f; // 5% concussion per 1 damage
+    
+    /// <summary>Arrow/Bolt impact - LOW concussion. Similar to bullets, penetrating impact.</summary>
+    public const float Arrow = 0.05f; // 5% concussion per 1 damage
+    
+    /// <summary>High-velocity arrows (Combat Extended) - LOW-MODERATE concussion.</summary>
+    public const float ArrowHighVelocity = 0.08f; // 8% concussion per 1 damage
+    
+    /// <summary>Stabbing wound - VERY LOW concussion. Minimal blunt force.</summary>
+    public const float Stab = 0.02f; // 2% concussion per 1 damage
+    
+    /// <summary>Crushing damage - HIGH concussion. Compressive trauma similar to blunt force.</summary>
+    public const float Crush = 0.18f; // 18% concussion per 1 damage
+    
+    /// <summary>Bite damage - MODERATE concussion. Localized impact with some force.</summary>
+    public const float Bite = 0.10f; // 10% concussion per 1 damage
+    
+    /// <summary>Toxic/Caustic damage - LOW concussion. Chemical burns don't cause concussions effectively.</summary>
+    public const float Toxic = 0.01f; // 1% concussion per 1 damage
+    
+    /// <summary>Nerve/EMP damage - MODERATE concussion. Electrical/neural stimulation.</summary>
+    public const float Nerve = 0.12f; // 12% concussion per 1 damage
+    
+    /// <summary>Energy/Plasma bolts - MODERATE-HIGH concussion. Heat + impact.</summary>
+    public const float EnergyBolt = 0.15f; // 15% concussion per 1 damage
+    
+    /// <summary>Beanbag/Non-lethal impact - MODERATE concussion. Designed for blunt trauma.</summary>
+    public const float Beanbag = 0.12f; // 12% concussion per 1 damage
+    
+    /// <summary>Unknown damage types from mods - CONSERVATIVE default.</summary>
+    public const float Default = 0.08f; // 8% concussion per 1 damage (conservative middle ground)
+}
+#endregion
+
 internal sealed class ConcussionExplosionsWorker(MoreInjuryComp parent) : InjuryWorker(parent), IPostPostApplyDamageHandler
 {
+
     public override bool IsEnabled => MoreInjuriesMod.Settings.EnableConcussion;
 
     public void PostPostApplyDamage(ref readonly DamageInfo dinfo)
     {
         Pawn patient = Pawn;
+
+        /*
+        //original code
         if (dinfo.Def is not null && KnownDamageGroupNames.Explosions.Value.Contains(dinfo.Def.defName))
         {
             // ((1 / e) * x) / ((1 / e) * x + 1)
@@ -35,5 +125,211 @@ internal sealed class ConcussionExplosionsWorker(MoreInjuryComp parent) : Injury
                 concussion.Severity = severity;
             }
         }
+        */
+
+        // Only process if damage went to a head-related part
+        BodyPartRecord? hitPart = dinfo.HitPart;
+        if (hitPart is null || !IsHeadPart(hitPart))
+        {
+            return;
+        }
+        
+        // Get the brain as target for the concussion hediff
+        BodyPartRecord? brain = patient.health.hediffSet.GetBrain();
+        if (brain is null)
+        {
+            return;
+        }
+        
+        // Get the damage type concussion percentage
+        float concussionPercentPerDamage = GetConcussionPercentageForDamage(dinfo.Def);
+        
+        // Get the body part multiplier based on the specific hit location
+        float bodyPartMultiplier = GetBodyPartMultiplier(hitPart);
+        
+        // Calculate the percentage of damage that reached this body part
+        // This accounts for armor reduction
+        float damagePercentageReached = CalculateDamagePercentageReached(dinfo.Amount, hitPart, patient);
+        
+        // Calculate total concussion severity
+        float concussionSeverity = CalculateConcussionSeverity(
+            dinfo.Amount,
+            damagePercentageReached,
+            bodyPartMultiplier,
+            concussionPercentPerDamage,
+            hitPart
+        );
+        
+        if (concussionSeverity < 0.01f)
+        {
+            // Ignore negligible concussion
+            return;
+        }
+        
+        // Apply or increase concussion hediff
+        if (!patient.health.hediffSet.TryGetHediff(KnownHediffDefOf.Concussion, out Hediff? concussion))
+        {
+            concussion = HediffMaker.MakeHediff(KnownHediffDefOf.Concussion, patient);
+            patient.health.AddHediff(concussion, brain);
+        }
+        
+        // Add to existing concussion severity, clamped to max
+        concussion.Severity = Mathf.Min(1.0f, concussion.Severity + concussionSeverity);
+        
+        Logger.LogDebug(
+            $"Applied {concussionSeverity:P} concussion to {patient.Name} from {dinfo.Amount:F2} damage " +
+            $"to {hitPart.Label} (multiplier: {bodyPartMultiplier}x, damage type: {dinfo.Def?.defName ?? "Unknown"}, " +
+            $"percent per dmg: {concussionPercentPerDamage:P}, actual reached: {damagePercentageReached:P})"
+        );
+
     }
+
+    // Determines if a body part is related to the head/brain and should cause concussions.
+    private static bool IsHeadPart(BodyPartRecord part)
+    {
+        // Check if it's the brain, skull, or any part in the head group
+        if (part.def == KnownBodyPartDefOf.Brain || 
+            part.def == KnownBodyPartDefOf.Skull ||
+            part.def == BodyPartDefOf.Head)
+        {
+            return true;
+        }
+        
+        // Check if it's a child/subpart of the head
+        for (BodyPartRecord? current = part.parent; current is not null; current = current.parent)
+        {
+            if (current.def == BodyPartDefOf.Head)
+            {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+
+    // Calculates what percentage of the total damage actually reached the target body part.
+    // This accounts for armor reduction by examining the body part's armor values.
+    private static float CalculateDamagePercentageReached(float totalDamage, BodyPartRecord targetPart, Pawn pawn)
+    {
+        if (totalDamage <= 0f)
+        {
+            return 0f;
+        }
+        
+        // Simple approximation: base damage reduction on body part coverage and armor
+        // Higher armor = lower percentage of damage reaches the part
+        float armorReduction = 1.0f;
+        
+        // Account for coverage (covered parts reduce impact damage more)
+        if (targetPart.coverage > 0f)
+        {
+            armorReduction *= targetPart.coverage;
+        }
+        
+        // A pawn with heavy armor takes less concussion damage, but some always gets through
+        // This is a simplification - a full implementation would use the damage result
+        float minDamagePercentage = 0.1f; // At least 10% of damage always reaches (serious hits)
+        float maxDamagePercentage = 1.0f; // At most 100% (no armor)
+        
+        return Mathf.Clamp(armorReduction, minDamagePercentage, maxDamagePercentage);
+    }
+
+    // Gets the body part multiplier based on the specific head region that was hit.
+    private static float GetBodyPartMultiplier(BodyPartRecord hitPart)
+    {
+        // Direct hits to the brain are most severe
+        if (hitPart.def == KnownBodyPartDefOf.Brain)
+        {
+            return ConcussionBodyPartMultipliers.Brain;
+        }
+        
+        // Skull hits are medium severity
+        if (hitPart.def == KnownBodyPartDefOf.Skull)
+        {
+            return ConcussionBodyPartMultipliers.Skull;
+        }
+        
+        // Generic head hits are least severe (dispersed impact)
+        if (hitPart.def == BodyPartDefOf.Head)
+        {
+            return ConcussionBodyPartMultipliers.Head;
+        }
+        
+        // Other head sub-parts (eyes, ears, jaw, etc.) get medium severity
+        if (hitPart.parent?.def == BodyPartDefOf.Head || hitPart.parent?.def == KnownBodyPartDefOf.Skull)
+        {
+            return ConcussionBodyPartMultipliers.Skull;
+        }
+        
+        return ConcussionBodyPartMultipliers.Default;
+    }
+
+    // Gets the concussion percentage generation for a specific damage type.
+    // Returns the percentage of concussion created per 1 point of damage.
+    // Unknown damage types get the default conservative value.
+    private static float GetConcussionPercentageForDamage(DamageDef? damageDef)
+    {
+        if (damageDef is null)
+        {
+            return ConcussionDamageTypePercentages.Default;
+        }
+        
+        string damageDefName = damageDef.defName;
+        
+        // Match against known damage types
+        return damageDefName switch
+        {
+            "Blunt" => ConcussionDamageTypePercentages.Blunt,
+            "Bomb" => ConcussionDamageTypePercentages.Bomb,
+            "BombSuper" => ConcussionDamageTypePercentages.Bomb,
+            "Bullet" => ConcussionDamageTypePercentages.Bullet,
+            "BulletToxic" => ConcussionDamageTypePercentages.Bullet,
+            "Stab" => ConcussionDamageTypePercentages.Stab,
+            "Crush" => ConcussionDamageTypePercentages.Crush,
+            
+            "Arrow" => ConcussionDamageTypePercentages.Arrow,
+            "ArrowHighVelocity" => ConcussionDamageTypePercentages.ArrowHighVelocity,
+            "Bite" => ConcussionDamageTypePercentages.Bite,
+            "BiteToxic" => ConcussionDamageTypePercentages.Toxic,
+            "Beanbag" => ConcussionDamageTypePercentages.Beanbag,
+            "EnergyBolt" => ConcussionDamageTypePercentages.EnergyBolt,
+            "Nerve" => ConcussionDamageTypePercentages.Nerve,
+            "Thermobaric" => ConcussionDamageTypePercentages.Thermobaric,
+            
+            // Unknown damage type - use conservative default
+            _ => ConcussionDamageTypePercentages.Default
+        };
+    }
+
+    // Calculates the final concussion severity based on received damage, body part sensitivity,
+    // and damage type, with scaling based on target body part's HP.
+    private static float CalculateConcussionSeverity(
+        float totalDamage,
+        float damagePercentageReached,
+        float bodyPartMultiplier,
+        float concussionPercentPerDamage,
+        BodyPartRecord targetPart)
+    {
+        // Actual damage that reached this part after armor/coverage reduction
+        float actualReceivedDamage = totalDamage * damagePercentageReached;
+        
+        // Base concussion = damage * damage type percentage * body part multiplier
+        float baseConcussion = actualReceivedDamage * concussionPercentPerDamage * bodyPartMultiplier;
+        
+        // Scale by target body part health - smaller brain = more concussion per damage
+        // This makes the same impact more severe on smaller creatures
+        float healthScaling = 1.0f;
+        if (targetPart.def.hitPoints > 0)
+        {
+            // Use base hit points from definition (e.g., brain = 10 HP base)
+            const float ReferenceHitPoints = 10.0f;
+            healthScaling = ReferenceHitPoints / targetPart.def.hitPoints;
+        }
+        
+        float finalConcussion = baseConcussion * healthScaling;
+        
+        // Clamp to reasonable range
+        return Mathf.Clamp(finalConcussion, 0f, 1.0f);
+    }
+
 }

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/HypovolemicShock/HediffComp_Shock.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/HypovolemicShock/HediffComp_Shock.cs
@@ -45,6 +45,35 @@ public class HediffComp_Shock : HediffComp
         return info;
     }
 
+
+    // Helper to check if pawn has oxygen deficiency immunity from Biotech/Odyssey genes
+    private static bool HasOxygenDeficiencyImmunity(Pawn pawn)
+    {
+        // Biotech required for genes system
+        if (!ModsConfig.BiotechActive || pawn.genes == null)
+        {
+            return false;
+        }
+
+        // "Deathless" gene from Biotech DLC - grants immunity to hypoxia and oxygen deficiency
+        GeneDef deathlessGene = DefDatabase<GeneDef>.GetNamedSilentFail("Deathless");
+        if (deathlessGene != null && pawn.genes.HasActiveGene(deathlessGene))
+        {
+            return true;
+        }
+
+        // "Breathless" gene from Odyssey mod - pawn doesn't need to breathe oxygen
+        GeneDef breathlessGene = DefDatabase<GeneDef>.GetNamedSilentFail("Breathless");
+        if (breathlessGene != null && pawn.genes.HasActiveGene(breathlessGene))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+
+
     public override void CompTended(float quality, float maxQuality, int batchPosition = 0)
     {
         base.CompTended(quality, maxQuality, batchPosition);
@@ -68,6 +97,16 @@ public class HediffComp_Shock : HediffComp
     public override void CompPostTick(ref float severityAdjustment)
     {
         Pawn pawn = parent.pawn;
+
+        // Check for oxygen deficiency immunity from Deathless/Breathless genes
+        // If pawn has either gene, they are immune to hypovolemic shock entirely
+        if (HasOxygenDeficiencyImmunity(pawn))
+        {
+            Logger.LogDebug($"Removing hypovolemic shock from {pawn.Name} due to oxygen-deficiency immunity gene");
+            pawn.health.RemoveHediff(parent);
+            return;
+        }
+
         if (!pawn.IsHashIntervalTick(CYCLE_LENGTH))
         {
             return;

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/HypovolemicShock/Secondary/HediffCompHandler_SecondaryCondition_CardiacArrest.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/HypovolemicShock/Secondary/HediffCompHandler_SecondaryCondition_CardiacArrest.cs
@@ -1,4 +1,5 @@
-﻿using MoreInjuries.HealthConditions.Secondary;
+﻿using MoreInjuries.Extensions;
+using MoreInjuries.HealthConditions.Secondary;
 using MoreInjuries.HealthConditions.Secondary.Handlers;
 using RimWorld;
 using UnityEngine;
@@ -15,32 +16,44 @@ public sealed class HediffCompHandler_SecondaryCondition_CardiacArrest : HediffC
             return true;
         }
 
-        // Don't apply cardiac arrest if pawn has an artificial heart
-        if (HasArtificialHeart(comp.parent.pawn))
-        {
-            return true; // Skip - pawn has artificial heart
-        }
+        Pawn pawn = comp.parent.pawn;
 
-        // if there is no blood loss, we don't apply cardiac arrest
-        if (!comp.parent.pawn.health.hediffSet.TryGetHediff(HediffDefOf.BloodLoss, out Hediff? bloodLoss) || bloodLoss.Severity < Mathf.Epsilon)
+        // Check for oxygen deficiency immunity from Deathless/Breathless genes FIRST
+        // This prevents cardiac arrest entirely for oxygen-immune pawns
+        if (pawn.HasOxygenDeficiencyImmunity())
         {
             return true;
         }
+
+        // Don't apply cardiac arrest if pawn has an artificial heart
+        if (HasArtificialHeart(pawn))
+        {
+            return true;
+        }
+
+        // if there is no blood loss, we don't apply cardiac arrest
+        if (!pawn.health.hediffSet.TryGetHediff(HediffDefOf.BloodLoss, out Hediff? bloodLoss) || bloodLoss.Severity < Mathf.Epsilon)
+        {
+            return true;
+        }
+
         // cardiac arrest chance is higher for higher blood loss
         float cardiacArrestChance = MoreInjuriesMod.Settings.CardiacArrestChanceOnHighBloodLoss * bloodLoss.Severity / 0.8f;
         if (!Rand.Chance(cardiacArrestChance))
         {
             return true;
         }
+
         // continue with the evaluation
         return false;
     }
 
+    // Check if pawn has any artificial heart replacement (bionic, prosthetic, etc.)
+    // Uses Hediff_AddedPart to properly distinguish artificial replacements from injuries/diseases
     private static bool HasArtificialHeart(Pawn pawn)
     {
-        // Check if pawn has an artificial heart
         return pawn.health.hediffSet.hediffs.Any(hediff =>
-            hediff.Part?.def == BodyPartDefOf.Heart && 
-            hediff.def.addedPartProps is not null);
+            hediff.Part?.def == BodyPartDefOf.Heart &&
+            hediff is Hediff_AddedPart);
     }
 }

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/HypovolemicShock/Secondary/HediffCompHandler_SecondaryCondition_CardiacArrest.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/HypovolemicShock/Secondary/HediffCompHandler_SecondaryCondition_CardiacArrest.cs
@@ -14,6 +14,13 @@ public sealed class HediffCompHandler_SecondaryCondition_CardiacArrest : HediffC
         {
             return true;
         }
+
+        // Don't apply cardiac arrest if pawn has an artificial heart
+        if (HasArtificialHeart(comp.parent.pawn))
+        {
+            return true; // Skip - pawn has artificial heart
+        }
+
         // if there is no blood loss, we don't apply cardiac arrest
         if (!comp.parent.pawn.health.hediffSet.TryGetHediff(HediffDefOf.BloodLoss, out Hediff? bloodLoss) || bloodLoss.Severity < Mathf.Epsilon)
         {
@@ -27,5 +34,13 @@ public sealed class HediffCompHandler_SecondaryCondition_CardiacArrest : HediffC
         }
         // continue with the evaluation
         return false;
+    }
+
+    private static bool HasArtificialHeart(Pawn pawn)
+    {
+        // Check if pawn has an artificial heart
+        return pawn.health.hediffSet.hediffs.Any(hediff =>
+            hediff.Part?.def == BodyPartDefOf.Heart && 
+            hediff.def.addedPartProps is not null);
     }
 }

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/HypovolemicShock/Secondary/HediffCompHandler_SecondaryCondition_Hypoxia.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/HypovolemicShock/Secondary/HediffCompHandler_SecondaryCondition_Hypoxia.cs
@@ -1,4 +1,5 @@
-﻿using MoreInjuries.HealthConditions.Secondary;
+﻿using MoreInjuries.Extensions;
+using MoreInjuries.HealthConditions.Secondary;
 using MoreInjuries.HealthConditions.Secondary.Handlers;
 using Verse;
 
@@ -8,6 +9,16 @@ public sealed class HediffCompHandler_SecondaryCondition_Hypoxia : HediffCompHan
 {
     public override float BaseChance => MoreInjuriesMod.Settings.OrganHypoxiaChance * base.BaseChance;
 
-    public override bool ShouldSkip(HediffComp_SecondaryCondition comp) => 
-        base.ShouldSkip(comp) || comp.parent.IsTended() && Rand.Chance(MoreInjuriesMod.Settings.OrganHypoxiaChanceReductionFactor);
+    public override bool ShouldSkip(HediffComp_SecondaryCondition comp) 
+    //=> 
+        //base.ShouldSkip(comp) || comp.parent.IsTended() && Rand.Chance(MoreInjuriesMod.Settings.OrganHypoxiaChanceReductionFactor);
+    {   
+        // Skip if pawn has oxygen-deficiency immunity (Deathless or Breathless genes)
+        if (comp.parent.pawn.HasOxygenDeficiencyImmunity())
+        {
+            return true;
+        }
+
+        return base.ShouldSkip(comp) || comp.parent.IsTended() && Rand.Chance(MoreInjuriesMod.Settings.OrganHypoxiaChanceReductionFactor);
+    }
 }

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/Hypoxia/Secondary/HediffCompHandler_SecondaryCondition_BrainDamage.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/Hypoxia/Secondary/HediffCompHandler_SecondaryCondition_BrainDamage.cs
@@ -1,4 +1,5 @@
-﻿using MoreInjuries.HealthConditions.Secondary;
+﻿using MoreInjuries.Extensions;
+using MoreInjuries.HealthConditions.Secondary;
 using MoreInjuries.HealthConditions.Secondary.Handlers;
 using Verse;
 
@@ -8,6 +9,14 @@ public sealed class HediffCompHandler_SecondaryCondition_BrainDamage : HediffCom
 {
     public override float BaseChance => MoreInjuriesMod.Settings.EnableNeuralDamage ? base.BaseChance : 0f;
 
-    public override bool ShouldSkip(HediffComp_SecondaryCondition comp) => base.ShouldSkip(comp) 
-        || comp.parent.IsTended() && Rand.Chance(MoreInjuriesMod.Settings.NeuralDamageChanceReductionFactor);
+    public override bool ShouldSkip(HediffComp_SecondaryCondition comp)
+    {
+        // Skip if pawn has oxygen-deficiency immunity (Deathless or Breathless genes)
+        if (comp.parent.pawn.HasOxygenDeficiencyImmunity())
+        {
+            return true;
+        }
+
+        return base.ShouldSkip(comp) || comp.parent.IsTended() && Rand.Chance(MoreInjuriesMod.Settings.NeuralDamageChanceReductionFactor);
+    }
 }

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/LungCollapse/LungCollapseWorkerBase.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/LungCollapse/LungCollapseWorkerBase.cs
@@ -13,6 +13,14 @@ internal abstract class LungCollapseWorkerBase(MoreInjuryComp parent) : InjuryWo
     protected void CollapseLung<TCause>(BodyPartRecord lung, params ReadOnlySpan<TCause> causes)
     {
         Pawn patient = Pawn;
+        
+        // Don't apply lung collapse to artificial lungs
+        if (patient.health.hediffSet.IsArtificialPart(lung))
+        {
+            Logger.LogDebug($"Won't apply lung collapse to {lung.Label} of {patient.Name} since it's an artificial lung");
+            return;
+        }
+
         float clampedUpperBound = Mathf.Clamp(MoreInjuriesMod.Settings.LungCollapseMaxSeverityRoot, 0.1f, 1.0f);
         float factor = Rand.Range(0.1f, clampedUpperBound);
         // we scale the severity by the square of the factor to make it more likely to be low, but allow for high values with a small chance

--- a/Source/MoreInjuries/MoreInjuries/MoreInjuries.csproj
+++ b/Source/MoreInjuries/MoreInjuries/MoreInjuries.csproj
@@ -3,7 +3,7 @@
 		<TargetFramework>net472</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<Version>1.6.0.2</Version>
+		<Version>1.6.0.3</Version>
 		<Platforms>AnyCPU</Platforms>
 		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 		<Configurations>Debug;Release;Test</Configurations>


### PR DESCRIPTION
This is my first ever pull request, sorry for any inconveniences.
I tried to add meaningful descriptions to most of the commits here.
C# part was done using Copilot so it may be not very good in terms of coding.

- This changes prices and crafting costs to somewhat logical and balanced around vanilla values. #112 
- Concussion now should scale with actually received damage.
- Brain hypoxia ticks much slower and doesn't at all for deathless/breathless pawns. #114 
- Cardiac arrest doesn't  happen if the heart is artificial. #116 
- Lung Collapse doesn't happen if the lung is artificial (works with anomaly ones too!)
- Reworked ChokingOnBlood for better integration with DeathRattle (temporary solution, I'd like to change it entirely to affect lungs precisely, not the Whole body) 

Suggesting this pull request right now mostly because of seeing you coming back to this mod, myself I'd like to improve it more over time.
In particular, I didn't finish reworking Lung Collapse to behave more like new Concussion - I got very frustrated by getting Concussions and Lung Collapses while my perfect power armor was deflecting incoming damage entirely.