### PR TITLE
thing modifiers

### DIFF
--- a/Defs/ThingDefs/Medicine/Medicine_Defibrillator.xml
+++ b/Defs/ThingDefs/Medicine/Medicine_Defibrillator.xml
@@ -22,7 +22,7 @@
     </statBases>
     <modExtensions>
       <li Class="MoreInjuries.Things.ReusabilityProps_ModExtension">
-        <destroyChanceModifier Class="ThingModifier_ConstantFactor">
+        <destroyChanceModifier Class="MoreInjuries.Things.ThingModifier_ConstantFactor">
           <factor>0.10</factor>
         </destroyChanceModifier>
       </li>

--- a/Defs/ThingDefs/Medicine/Medicine_Defibrillator.xml
+++ b/Defs/ThingDefs/Medicine/Medicine_Defibrillator.xml
@@ -22,7 +22,9 @@
     </statBases>
     <modExtensions>
       <li Class="MoreInjuries.Things.ReusabilityProps_ModExtension">
-        <destroyChance>0.10</destroyChance>
+        <destroyChanceModifier Class="ThingModifier_ConstantFactor">
+          <factor>0.10</factor>
+        </destroyChanceModifier>
       </li>
     </modExtensions>
     <thingCategories>

--- a/Defs/ThingDefs/Medicine/Medicine_Thoracoscope.xml
+++ b/Defs/ThingDefs/Medicine/Medicine_Thoracoscope.xml
@@ -22,7 +22,9 @@
     </statBases>
     <modExtensions>
       <li Class="MoreInjuries.Things.ReusabilityProps_ModExtension">
-        <destroyChance>0.2</destroyChance>
+        <destroyChanceModifier Class="ThingModifier_ConstantFactor">
+          <factor>0.20</factor>
+        </destroyChanceModifier>
       </li>
     </modExtensions>
     <thingCategories>

--- a/Defs/ThingDefs/Medicine/Medicine_Thoracoscope.xml
+++ b/Defs/ThingDefs/Medicine/Medicine_Thoracoscope.xml
@@ -22,7 +22,7 @@
     </statBases>
     <modExtensions>
       <li Class="MoreInjuries.Things.ReusabilityProps_ModExtension">
-        <destroyChanceModifier Class="ThingModifier_ConstantFactor">
+        <destroyChanceModifier Class="MoreInjuries.Things.ThingModifier_ConstantFactor">
           <factor>0.20</factor>
         </destroyChanceModifier>
       </li>

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/Secondary/Handlers/Modifiers/HediffModifier_Settings_Gauge.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/Secondary/Handlers/Modifiers/HediffModifier_Settings_Gauge.cs
@@ -6,11 +6,11 @@ public sealed class HediffModifier_Settings_Gauge : HediffModifier_Settings
 {
     public override float GetModifier(Hediff hediff, HediffCompHandler compHandler)
     {
-        string feature = Key;
-        if (!MoreInjuriesMod.Settings.Keyed.TryGetMember(feature, out float gauge))
+        string gaugeKey = Key;
+        if (!MoreInjuriesMod.Settings.Keyed.TryGetMember(gaugeKey, out float gauge))
         {
             // if the key does not exist or does not match the expected type, we return the base chance
-            Logger.ConfigError($"{feature} is not a valid feature flag in the settings. Cannot evaluate chance.");
+            Logger.ConfigError($"{gaugeKey} is not a valid key in the settings. Cannot evaluate chance.");
             return 1f;
         }
         // if there is a valid gauge value associated with the key, we return it

--- a/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier.cs
+++ b/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier.cs
@@ -1,0 +1,8 @@
+﻿using Verse;
+
+namespace MoreInjuries.Things.Modifiers;
+
+public abstract class ThingModifier
+{
+    public abstract float GetModifier(Thing thing);
+}

--- a/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier_Collection.cs
+++ b/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier_Collection.cs
@@ -13,7 +13,8 @@ public sealed class ThingModifier_Collection : ThingModifier
     {
         if (modifiers is not [_, ..])
         {
-            throw new InvalidOperationException("ThingModifier_Collection must contain at least one modifier to be evaluated.");
+            Logger.ConfigError($"{nameof(ThingModifier_Collection)} has no modifiers. This is likely a mistake in the XML definition. Returning 1 as the modifier value.");
+            return 1f;
         }
         float modifier = 1f;
         foreach (ThingModifier thingModifier in modifiers)

--- a/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier_Collection.cs
+++ b/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier_Collection.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using Verse;
+
+namespace MoreInjuries.Things.Modifiers;
+
+[SuppressMessage(CODE_STYLE, STYLE_IDE1006_NAMING_STYLES, Justification = JUSTIFY_IDE1006_XML_NAMING_CONVENTION)]
+public sealed class ThingModifier_Collection : ThingModifier
+{
+    // don't rename this field. XML defs depend on this name
+    private readonly List<ThingModifier> modifiers = default!;
+
+    public override float GetModifier(Thing thing)
+    {
+        if (modifiers is not [_, ..])
+        {
+            throw new InvalidOperationException("ThingModifier_Collection must contain at least one modifier to be evaluated.");
+        }
+        float modifier = 1f;
+        foreach (ThingModifier thingModifier in modifiers)
+        {
+            modifier *= thingModifier.GetModifier(thing);
+        }
+        return modifier;
+    }
+}

--- a/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier_ConstantFactor.cs
+++ b/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier_ConstantFactor.cs
@@ -1,0 +1,12 @@
+﻿using Verse;
+
+namespace MoreInjuries.Things.Modifiers;
+
+[SuppressMessage(CODE_STYLE, STYLE_IDE1006_NAMING_STYLES, Justification = JUSTIFY_IDE1006_XML_NAMING_CONVENTION)]
+public class ThingModifier_ConstantFactor : ThingModifier
+{
+    // don't rename this field. XML defs depend on this name
+    protected readonly float factor = default!;
+
+    public override float GetModifier(Thing thing) => factor;
+}

--- a/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier_Settings.cs
+++ b/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier_Settings.cs
@@ -1,0 +1,20 @@
+﻿using MoreInjuries.Roslyn.Future.ThrowHelpers;
+
+namespace MoreInjuries.Things.Modifiers;
+
+[SuppressMessage(CODE_STYLE, STYLE_IDE1006_NAMING_STYLES, Justification = JUSTIFY_IDE1006_XML_NAMING_CONVENTION)]
+[SuppressMessage(CODE_STYLE, STYLE_IDE0032_USE_AUTO_PROPERTY, Justification = JUSTIFY_IDE0032_XML_DEF_REQUIRES_FIELD)]
+public abstract class ThingModifier_Settings : ThingModifier
+{
+    // don't rename this field. XML defs depend on this name
+    private readonly string? key = null;
+
+    public string Key
+    {
+        get
+        {
+            Throw.InvalidOperationException.IfNullOrEmpty(this, key); 
+            return key;
+        }
+    }
+}

--- a/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier_Settings_FeatureFlag.cs
+++ b/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier_Settings_FeatureFlag.cs
@@ -1,0 +1,24 @@
+﻿using Verse;
+
+namespace MoreInjuries.Things.Modifiers;
+
+public class ThingModifier_Settings_FeatureFlag : ThingModifier_Settings
+{
+    public override float GetModifier(Thing thing)
+    {
+        string feature = Key;
+        if (!MoreInjuriesMod.Settings.Keyed.TryGetMember(feature, out bool flag))
+        {
+            // if the feature flag does not exist or does not match the expected type, we return the base chance
+            Logger.ConfigError($"{feature} is not a valid feature flag in the settings. Cannot evaluate chance.");
+            return 1f;
+        }
+        if (!flag)
+        {
+            // if the feature flag is disabled, we return 0 chance
+            return 0f;
+        }
+        // if the feature flag is enabled, we return the base chance
+        return 1f;
+    }
+}

--- a/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier_Settings_FeatureFlag_Disabled.cs
+++ b/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier_Settings_FeatureFlag_Disabled.cs
@@ -1,0 +1,8 @@
+﻿using Verse;
+
+namespace MoreInjuries.Things.Modifiers;
+
+public sealed class ThingModifier_Settings_FeatureFlag_Disabled : ThingModifier_Settings_FeatureFlag
+{
+    public override float GetModifier(Thing thing) => 1f - base.GetModifier(thing);
+}

--- a/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier_Settings_Gauge.cs
+++ b/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier_Settings_Gauge.cs
@@ -6,11 +6,11 @@ public sealed class ThingModifier_Settings_Gauge : ThingModifier_Settings
 {
     public override float GetModifier(Thing thing)
     {
-        string feature = Key;
-        if (!MoreInjuriesMod.Settings.Keyed.TryGetMember(feature, out float gauge))
+        string gaugeKey = Key;
+        if (!MoreInjuriesMod.Settings.Keyed.TryGetMember(gaugeKey, out float gauge))
         {
             // if the key does not exist or does not match the expected type, we return the base chance
-            Logger.ConfigError($"{feature} is not a valid feature flag in the settings. Cannot evaluate chance.");
+            Logger.ConfigError($"{gaugeKey} is not a valid key in the settings. Cannot evaluate chance.");
             return 1f;
         }
         // if there is a valid gauge value associated with the key, we return it

--- a/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier_Settings_Gauge.cs
+++ b/Source/MoreInjuries/MoreInjuries/Things/Modifiers/ThingModifier_Settings_Gauge.cs
@@ -1,0 +1,19 @@
+﻿using Verse;
+
+namespace MoreInjuries.Things.Modifiers;
+
+public sealed class ThingModifier_Settings_Gauge : ThingModifier_Settings
+{
+    public override float GetModifier(Thing thing)
+    {
+        string feature = Key;
+        if (!MoreInjuriesMod.Settings.Keyed.TryGetMember(feature, out float gauge))
+        {
+            // if the key does not exist or does not match the expected type, we return the base chance
+            Logger.ConfigError($"{feature} is not a valid feature flag in the settings. Cannot evaluate chance.");
+            return 1f;
+        }
+        // if there is a valid gauge value associated with the key, we return it
+        return gauge;
+    }
+}

--- a/Source/MoreInjuries/MoreInjuries/Things/ReusabilityProps_ModExtension.cs
+++ b/Source/MoreInjuries/MoreInjuries/Things/ReusabilityProps_ModExtension.cs
@@ -1,4 +1,5 @@
-﻿using Verse;
+﻿using MoreInjuries.Things.Modifiers;
+using Verse;
 
 namespace MoreInjuries.Things;
 
@@ -8,7 +9,7 @@ namespace MoreInjuries.Things;
 public class ReusabilityProps_ModExtension : DefModExtension
 {
     // don't rename this field. XML defs depend on this name
-    private readonly float destroyChance = default;
+    private readonly ThingModifier destroyChanceModifier = default!;
 
-    public float DestroyChance => destroyChance;
+    public ThingModifier DestroyChanceModifier => destroyChanceModifier;
 }

--- a/Source/MoreInjuries/MoreInjuries/Things/ReusabilityUtility.cs
+++ b/Source/MoreInjuries/MoreInjuries/Things/ReusabilityUtility.cs
@@ -9,9 +9,10 @@ public static class ReusabilityUtility
 {
     public static void TryReuseSurgeryIngredient(Thing ingredient, Pawn doctor, Pawn patient)
     {
-        if (ingredient.def.GetModExtension<ReusabilityProps_ModExtension>() is { DestroyChance: float destroyChance })
+        if (ingredient.def.GetModExtension<ReusabilityProps_ModExtension>() is { DestroyChanceModifier: { } destroyChanceModifier })
         {
-            if (Rand.Chance(destroyChance))
+            float chance = destroyChanceModifier.GetModifier(ingredient);
+            if (Rand.Chance(chance))
             {
                 Messages.Message(Named.Keys.Message_ProcedureIngredientDestroyed.Translate(doctor.Named(Named.Params.DOCTOR), ingredient.Named(Named.Params.THING)), doctor, MessageTypeDefOf.NegativeEvent);
             }
@@ -32,9 +33,10 @@ public static class ReusabilityUtility
 
     public static void TryDestroyReusableIngredient(Thing ingredient, Pawn doctor, bool destroyStack = true)
     {
-        if (ingredient.def.GetModExtension<ReusabilityProps_ModExtension>() is { DestroyChance: float destroyChance })
+        if (ingredient.def.GetModExtension<ReusabilityProps_ModExtension>() is { DestroyChanceModifier: { } destroyChanceModifier })
         {
-            if (Rand.Chance(destroyChance))
+            float chance = destroyChanceModifier.GetModifier(ingredient);
+            if (Rand.Chance(chance))
             {
                 Messages.Message(Named.Keys.Message_ProcedureIngredientDestroyed.Translate(doctor.Named(Named.Params.DOCTOR), ingredient.Named(Named.Params.THING)), doctor, MessageTypeDefOf.NegativeEvent);
                 if (destroyStack)

--- a/docs/coding-style.md
+++ b/docs/coding-style.md
@@ -87,9 +87,9 @@ Since RimWorld is built on Unity engine, above rules apply with the following ex
 public class ReusabilityProps_ModExtension : DefModExtension
 {
     // don't rename this field. XML defs depend on this name
-    private readonly float destroyChance = default;
+    private readonly ThingModifier destroyChanceModifier = default!;
 
-    public float DestroyChance => destroyChance;
+    public ThingModifier DestroyChanceModifier => destroyChanceModifier;
 }
 ```
 


### PR DESCRIPTION
This pull request refactors how destroy chance modifiers for reusable medical items are defined and evaluated. Instead of using a simple float value for destroy chance, the system now supports more flexible and extensible "modifier" classes, allowing for dynamic calculation of destroy chances based on settings or other logic.

Key changes include:

### Destroy Chance Refactor

* Replaced the `destroyChance` float in `ReusabilityProps_ModExtension` with a `ThingModifier` reference, enabling dynamic evaluation of destroy chance. All code and XML definitions now use `destroyChanceModifier` instead of a static value. [[1]](diffhunk://#diff-16beb26b1fa248f62b46bf4e7bc6dbf04e40af96ca879c6d7354a42e8e4f68f9L11-R14) [[2]](diffhunk://#diff-d39dd52f96ded0f325e976752f070b173ace04c69fbd1c45f82d215b9d98e719L12-R15) [[3]](diffhunk://#diff-d39dd52f96ded0f325e976752f070b173ace04c69fbd1c45f82d215b9d98e719L35-R39) [[4]](diffhunk://#diff-97af9453fc31908984cd35ed7c844a872567c491f418e909816ff9f3e59b3508L90-R92) [[5]](diffhunk://#diff-6eaf7bd7f631fe9fc72b36f663bad11c5566589f7de3dd8b57d48c2b565f2ed8L25-R27) [[6]](diffhunk://#diff-473c75ea5d2b0922afa8810c0a71bf964cb09684276c80cbfcb5a122e71bcfb9L25-R27)

### ThingModifier System

* Introduced an extensible `ThingModifier` abstract class and several implementations, including:
  - [`ThingModifier_ConstantFactor`](diffhunk://#diff-cdc3b8ed5e767f9ec9ec91a93aab58b8c432eaa2c6fe6809b26011482cdb6462R1-R12): Returns a constant factor, replacing previous static float values in XML.
  - [`ThingModifier_Collection`](diffhunk://#diff-9cd05e650afb814b1d06c8ed45defcaa88fd3ce3d4f110f719ab687d9c1ce9c9R1-R25): Allows combining multiple modifiers multiplicatively.
  - `ThingModifier_Settings`, `ThingModifier_Settings_FeatureFlag`, `ThingModifier_Settings_FeatureFlag_Disabled`, and `ThingModifier_Settings_Gauge`: Allow destroy chance to be controlled by mod settings or feature flags. [[1]](diffhunk://#diff-650b8bef5d383a6447c161fe9fde1874177e44ed9d5b91b21c3f6967ab250023R1-R20) [[2]](diffhunk://#diff-9052156c7b5c6d71bb73db6a401150f4dc08773bc3cf3109d956a3b7f3307329R1-R24) [[3]](diffhunk://#diff-bc19032516abf9a120772654194ba4bcc5a9d96f1b47fdfdf39195b51465c1b3R1-R8) [[4]](diffhunk://#diff-5c6639d42dcc2cf0e966831ddb43b8d6f34aa25aa0b9005f5033f537b2818a42R1-R19) [[5]](diffhunk://#diff-d26521f41060f357bd374d3d6bf697ef444f2f006ef70b2c4c9cf3b9bedda5e3R1-R8)

### XML and Code Updates

* Updated XML definitions for medical items to use the new `destroyChanceModifier` structure with `ThingModifier_ConstantFactor`. [[1]](diffhunk://#diff-6eaf7bd7f631fe9fc72b36f663bad11c5566589f7de3dd8b57d48c2b565f2ed8L25-R27) [[2]](diffhunk://#diff-473c75ea5d2b0922afa8810c0a71bf964cb09684276c80cbfcb5a122e71bcfb9L25-R27)
* Updated relevant code in `ReusabilityUtility` to evaluate destroy chance using the new modifier system. [[1]](diffhunk://#diff-d39dd52f96ded0f325e976752f070b173ace04c69fbd1c45f82d215b9d98e719L12-R15) [[2]](diffhunk://#diff-d39dd52f96ded0f325e976752f070b173ace04c69fbd1c45f82d215b9d98e719L35-R39)

These changes make the destroy chance system much more flexible and maintainable, allowing for future extensions and configuration via mod settings.