### PR TITLE
Dummy hostconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -369,5 +369,5 @@ artifacts/
 *.swp
 *.swo
 
-# articles that aren't open-access
-/assets/simulation/**/sci-hub-*.pdf
+# local config files
+hostconfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -371,3 +371,6 @@ artifacts/
 
 # local config files
 hostconfig.json
+
+# articles that aren't open-access
+/assets/simulation/**/sci-hub-*.pdf

--- a/Source/MoreInjuries/MoreInjuries/_build/hostconfig.json
+++ b/Source/MoreInjuries/MoreInjuries/_build/hostconfig.json
@@ -1,3 +1,3 @@
 {
-  "steam_root": "/path/to/your/steam/library"
+  "steam_root": "<path-to-your-steam-library, this directory should contain the 'steamapps' directory>"
 }

--- a/Source/MoreInjuries/MoreInjuries/_build/hostconfig.json
+++ b/Source/MoreInjuries/MoreInjuries/_build/hostconfig.json
@@ -1,3 +1,3 @@
 {
-  "steam_root": "G:/SteamLibrary"
+  "steam_root": "/path/to/your/steam/library"
 }


### PR DESCRIPTION
This pull request updates the `steam_root` path in the `hostconfig.json` configuration file to use a generic placeholder instead of a specific user path.

Configuration update:

* Changed the value of `steam_root` in `hostconfig.json` from a user-specific directory to a generic placeholder path.