### PR TITLE
fix(_build): make install-dependencies.sh portable on macOS

### DIFF
--- a/Source/MoreInjuries/MoreInjuries/_build/install-dependencies.sh
+++ b/Source/MoreInjuries/MoreInjuries/_build/install-dependencies.sh
@@ -3,10 +3,12 @@
 # Abort on any error, unset variable, or failed pipeline
 set -euo pipefail
 
-# Resolve script directory
-script_dir="$(/usr/bin/realpath "$(/usr/bin/dirname "${BASH_SOURCE[0]}")")"
+# Resolve script directory. Use cd + pwd -P (POSIX, no realpath dependency)
+# so this works on macOS where realpath is either missing or lives at
+# /opt/homebrew/bin/realpath rather than /usr/bin/realpath.
+script_dir="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # Resolve project root (4 levels up from script directory)
-mod_root="$(/usr/bin/realpath "${script_dir}/../../../..")"
+mod_root="$(cd -- "${script_dir}/../../../.." && pwd -P)"
 
 # Read steam_root from hostconfig.json
 steam_root="$(jq -r '.steam_root' "${script_dir}/hostconfig.json")"
@@ -17,21 +19,22 @@ dest_dir="${script_dir}/dependencies"
 # Expand {vars} placeholders using values passed in env to sed
 expand_placeholders() {
   local s="$1"
-  # GNU sed: replace placeholders with current values
   # NOTE: assumes no literal '|' in paths; typical filesystem paths are fine.
-  printf '%s' "$s" | /usr/bin/sed -e "s|{steam_root}|${steam_root}|g" \
-                                  -e "s|{workshop_root}|${workshop_root}|g" \
-                                  -e "s|{name}|${name}|g"
+  # Bare `sed` rather than /usr/bin/sed so PATH-overridden GNU sed (gsed
+  # symlink, brew) is honoured on macOS where the system sed is BSD.
+  printf '%s' "$s" | sed -e "s|{steam_root}|${steam_root}|g" \
+                         -e "s|{workshop_root}|${workshop_root}|g" \
+                         -e "s|{name}|${name}|g"
 }
 
 # Load and expand workshop_root template
 workshop_root_tpl="$(jq -r '.workshop_root' "$deps_json")"
 # For workshop_root expansion, name isn't meaningful, but keep it defined
 name=""
-workshop_root="$(printf '%s' "$workshop_root_tpl" | /usr/bin/sed -e "s|{steam_root}|${steam_root}|g")"
+workshop_root="$(printf '%s' "$workshop_root_tpl" | sed -e "s|{steam_root}|${steam_root}|g")"
 
 # Ensure destination directory exists
-/usr/bin/mkdir -p "$dest_dir"
+mkdir -p -- "$dest_dir"
 
 # Iterate dependencies
 count="$(jq -r '.dependencies | length' "$deps_json")"
@@ -42,7 +45,7 @@ for ((i=0; i<count; i++)); do
   src_path="$(expand_placeholders "$path_tpl")"
   dest_path="${dest_dir}/${name}"
 
-  /bin/cp "$src_path" "$dest_path"
+  cp -- "$src_path" "$dest_path"
 done
 
 echo "Dependencies copied to dependencies folder"

--- a/Source/MoreInjuries/MoreInjuries/_build/install-dependencies.sh
+++ b/Source/MoreInjuries/MoreInjuries/_build/install-dependencies.sh
@@ -7,8 +7,6 @@ set -euo pipefail
 # so this works on macOS where realpath is either missing or lives at
 # /opt/homebrew/bin/realpath rather than /usr/bin/realpath.
 script_dir="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-# Resolve project root (4 levels up from script directory)
-mod_root="$(cd -- "${script_dir}/../../../.." && pwd -P)"
 
 # Read steam_root from hostconfig.json
 steam_root="$(jq -r '.steam_root' "${script_dir}/hostconfig.json")"


### PR DESCRIPTION
Resolves #159 (same root cause as #152).

\`deploy.sh\` has already been migrated away from \`realpath\` and absolute \`/usr/bin/\` paths, but \`install-dependencies.sh\` still uses both, so it fails on macOS:

- \`realpath\` is not always present on macOS; when installed via Homebrew it lives at \`/opt/homebrew/bin/realpath\`, not \`/usr/bin/realpath\`.
- \`/bin/cp\`, \`/usr/bin/sed\`, \`/usr/bin/mkdir\`, \`/usr/bin/dirname\` are not the same set of binaries Homebrew's coreutils users expect on PATH.

## Changes

| Was | Now |
| --- | --- |
| \`/usr/bin/realpath\` (script_dir, mod_root) | \`cd -- ... && pwd -P\` — POSIX, matches \`deploy.sh\` |
| \`/usr/bin/dirname\` | bare \`dirname\` |
| \`/usr/bin/sed\` | bare \`sed\` |
| \`/usr/bin/mkdir "$dest_dir"\` | \`mkdir -p -- "$dest_dir"\` |
| \`/bin/cp\` | \`cp -- ...\` |

The \`--\` argument terminators on \`mkdir\` / \`cp\` protect against paths starting with \`-\`. The file is now also newline-terminated.