### PR TITLE
Configurable defibrillator break chance

### DIFF
--- a/Defs/ThingDefs/Medicine/Medicine_Defibrillator.xml
+++ b/Defs/ThingDefs/Medicine/Medicine_Defibrillator.xml
@@ -22,8 +22,8 @@
     </statBases>
     <modExtensions>
       <li Class="MoreInjuries.Things.ReusabilityProps_ModExtension">
-        <destroyChanceModifier Class="MoreInjuries.Things.ThingModifier_ConstantFactor">
-          <factor>0.10</factor>
+        <destroyChanceModifier Class="MoreInjuries.Things.ThingModifier_Settings_Gauge">
+          <key>DefibrillatorBreakOnUseRate</key>
         </destroyChanceModifier>
       </li>
     </modExtensions>

--- a/Defs/ThingDefs/Medicine/Medicine_Defibrillator.xml
+++ b/Defs/ThingDefs/Medicine/Medicine_Defibrillator.xml
@@ -22,8 +22,8 @@
     </statBases>
     <modExtensions>
       <li Class="MoreInjuries.Things.ReusabilityProps_ModExtension">
-        <destroyChanceModifier Class="MoreInjuries.Things.Modifiers.ThingModifier_ConstantFactor">
-          <factor>0.10</factor>
+        <destroyChanceModifier Class="MoreInjuries.Things.Modifiers.ThingModifier_Settings_Gauge">
+          <key>DefibrillatorBreakOnUseRate</key>
         </destroyChanceModifier>
       </li>
     </modExtensions>

--- a/Defs/ThingDefs/Medicine/Medicine_Defibrillator.xml
+++ b/Defs/ThingDefs/Medicine/Medicine_Defibrillator.xml
@@ -22,8 +22,8 @@
     </statBases>
     <modExtensions>
       <li Class="MoreInjuries.Things.ReusabilityProps_ModExtension">
-        <destroyChanceModifier Class="MoreInjuries.Things.ThingModifier_Settings_Gauge">
-          <key>DefibrillatorBreakOnUseRate</key>
+        <destroyChanceModifier Class="MoreInjuries.Things.Modifiers.ThingModifier_ConstantFactor">
+          <factor>0.10</factor>
         </destroyChanceModifier>
       </li>
     </modExtensions>

--- a/Defs/ThingDefs/Medicine/Medicine_Thoracoscope.xml
+++ b/Defs/ThingDefs/Medicine/Medicine_Thoracoscope.xml
@@ -22,7 +22,7 @@
     </statBases>
     <modExtensions>
       <li Class="MoreInjuries.Things.ReusabilityProps_ModExtension">
-        <destroyChanceModifier Class="MoreInjuries.Things.ThingModifier_ConstantFactor">
+        <destroyChanceModifier Class="MoreInjuries.Things.Modifiers.ThingModifier_ConstantFactor">
           <factor>0.20</factor>
         </destroyChanceModifier>
       </li>

--- a/Languages/English/Keyed/Lang_Settings.xml
+++ b/Languages/English/Keyed/Lang_Settings.xml
@@ -126,6 +126,10 @@
   <MI_Settings_Features_HypovolemicShock_CardiacArrestDefibrillationChanceLabel>Minimum defibrillator success rate for unskilled user: {VALUE} (default: {DEFAULT})</MI_Settings_Features_HypovolemicShock_CardiacArrestDefibrillationChanceLabel>
   <!-- EN: The minimum likelihood of a defibrillator successfully resuscitating a patient when used by an unskilled user (Medicine skill < 8).\n\nThe actual success rate scales with the user's medicine skill: max(<this setting>, <medicine skill> / 8). -->
   <MI_Settings_Features_HypovolemicShock_CardiacArrestDefibrillationChanceTooltip>The minimum likelihood of a defibrillator successfully resuscitating a patient when used by an unskilled user (Medicine skill &lt; 8).\n\nThe actual success rate scales with the user's medicine skill: max(&lt;this setting&gt;, &lt;medicine skill&gt; / 8).</MI_Settings_Features_HypovolemicShock_CardiacArrestDefibrillationChanceTooltip>
+  <!-- EN: Chance of a defibrillator breaking after use: {VALUE} (default: {DEFAULT}) -->
+  <MI_Settings_Features_HypovolemicShock_DestroyDefibrillatorOnUseChanceLabel>Chance of a defibrillator breaking after use: {VALUE} (default: {DEFAULT})</MI_Settings_Features_HypovolemicShock_DestroyDefibrillatorOnUseChanceLabel>
+  <!-- EN: A defibrillator has a chance of breaking after each use, which is configurable via this setting. -->
+  <MI_Settings_Features_HypovolemicShock_DestroyDefibrillatorOnUseChanceTooltip>A defibrillator has a chance of breaking after each use, which is configurable via this setting.</MI_Settings_Features_HypovolemicShock_DestroyDefibrillatorOnUseChanceTooltip>
   <!-- =========== Feature: Lethal Triad of Trauma ============ -->
   <!-- EN: Lethal Triad of Trauma -->
   <MI_Settings_Features_LethalTriad>Lethal Triad of Trauma</MI_Settings_Features_LethalTriad>

--- a/Source/MoreInjuries/MoreInjuries/MoreInjuriesMod.cs
+++ b/Source/MoreInjuries/MoreInjuries/MoreInjuriesMod.cs
@@ -16,7 +16,7 @@ public class MoreInjuriesMod : Mod
 
     public static MoreInjuriesSettings Settings { get; private set; } = null!;
 
-    internal static bool CombatExtendedLoaded => 
+    internal static bool CombatExtendedLoaded =>
         s_combatExtendedLoaded ??= LoadedModManager.RunningModsListForReading.Any(static mod => mod.PackageIdPlayerFacing?.Equals("CETeam.CombatExtended") is true);
 
     public MoreInjuriesMod(ModContentPack content) : base(content)
@@ -166,6 +166,9 @@ public class MoreInjuriesMod : Mod
         list.Label("MI_Settings_Features_HypovolemicShock_CardiacArrestDefibrillationChanceLabel".Translate(Settings.DefibrillatorMinimumSuccessRate.NamedValue(), DEFIBRILLATOR_MINIMUM_SUCCESS_RATE_DEFAULT.NamedDefault()), -1,
             "MI_Settings_Features_HypovolemicShock_CardiacArrestDefibrillationChanceTooltip".Translate());
         Settings.DefibrillatorMinimumSuccessRate = (float)Math.Round(list.Slider(Settings.DefibrillatorMinimumSuccessRate, 0f, 1f), 2);
+        list.Label("MI_Settings_Features_HypovolemicShock_DestroyDefibrillatorOnUseChanceLabel".Translate(Settings.DefibrillatorBreakOnUseRate.NamedValue(), DEFIBRILLATOR_BREAK_ON_USE_RATE_DEFAULT.NamedDefault()), -1,
+            "MI_Settings_Features_HypovolemicShock_DestroyDefibrillatorOnUseChanceTooltip".Translate());
+        Settings.DefibrillatorMinimumSuccessRate = (float)Math.Round(list.Slider(Settings.DefibrillatorBreakOnUseRate, 0f, 1f), 2);
         // trauma simulation
         list.GapLine();
         Text.Font = GameFont.Medium;

--- a/Source/MoreInjuries/MoreInjuries/MoreInjuriesMod.cs
+++ b/Source/MoreInjuries/MoreInjuries/MoreInjuriesMod.cs
@@ -168,7 +168,7 @@ public class MoreInjuriesMod : Mod
         Settings.DefibrillatorMinimumSuccessRate = (float)Math.Round(list.Slider(Settings.DefibrillatorMinimumSuccessRate, 0f, 1f), 2);
         list.Label("MI_Settings_Features_HypovolemicShock_DestroyDefibrillatorOnUseChanceLabel".Translate(Settings.DefibrillatorBreakOnUseRate.NamedValue(), DEFIBRILLATOR_BREAK_ON_USE_RATE_DEFAULT.NamedDefault()), -1,
             "MI_Settings_Features_HypovolemicShock_DestroyDefibrillatorOnUseChanceTooltip".Translate());
-        Settings.DefibrillatorMinimumSuccessRate = (float)Math.Round(list.Slider(Settings.DefibrillatorBreakOnUseRate, 0f, 1f), 2);
+        Settings.DefibrillatorBreakOnUseRate = (float)Math.Round(list.Slider(Settings.DefibrillatorBreakOnUseRate, 0f, 1f), 2);
         // trauma simulation
         list.GapLine();
         Text.Font = GameFont.Medium;

--- a/Source/MoreInjuries/MoreInjuries/MoreInjuriesSettings.cs
+++ b/Source/MoreInjuries/MoreInjuries/MoreInjuriesSettings.cs
@@ -9,10 +9,10 @@ namespace MoreInjuries;
 public partial class MoreInjuriesSettings : ModSettings
 {
     // logging
-    [SettingsEntry<bool>(DefaultValue = false)] 
+    [SettingsEntry<bool>(DefaultValue = false)]
     internal partial ref bool EnableLogging { get; }
 
-    [SettingsEntry<bool>(DefaultValue = false)] 
+    [SettingsEntry<bool>(DefaultValue = false)]
     internal partial ref bool EnableVerboseLogging { get; }
 
     // adrenaline and epinephrine
@@ -24,25 +24,25 @@ public partial class MoreInjuriesSettings : ModSettings
 
     [SettingsEntry<float>(DefaultValue = 15f)]
     internal partial ref float CertainAdrenalineThreshold { get; }
-    
+
     // blood transfusions
     [SettingsEntry<int>(DefaultValue = 5)]
     internal partial ref int BloodTransfusionHarvestMinimumSkill { get; }
-    
+
     // hydrostatic shock
     [SettingsEntry<bool>(DefaultValue = false)]
     internal partial ref bool EnableHydrostaticShock { get; }
 
     [SettingsEntry<float>(DefaultValue = 0.2f)]
     internal partial ref float HydrostaticShockChanceOnDamage { get; }
-    
+
     // EMP
     [SettingsEntry<bool>(DefaultValue = true)]
     internal partial ref bool EnableEmpDamageToBionics { get; }
 
     [SettingsEntry<float>(DefaultValue = 0.45f)]
     internal partial ref float EmpDamageToBionicsChance { get; }
-    
+
     // hemorrhagic stroke
     [SettingsEntry<bool>(DefaultValue = true)]
     internal partial ref bool EnableHemorrhagicStroke { get; }
@@ -52,7 +52,7 @@ public partial class MoreInjuriesSettings : ModSettings
 
     [SettingsEntry<float>(DefaultValue = 15f)]
     internal partial ref float HemorrhagicStrokeThreshold { get; }
-    
+
     // concussions
     [SettingsEntry<bool>(DefaultValue = true)]
     internal partial ref bool EnableConcussion { get; }
@@ -62,7 +62,7 @@ public partial class MoreInjuriesSettings : ModSettings
 
     [SettingsEntry<float>(DefaultValue = 6f)]
     internal partial ref float ConcussionThreshold { get; }
-    
+
     // choking
     [SettingsEntry<bool>(DefaultValue = true)]
     internal partial ref bool EnableChoking { get; }
@@ -78,7 +78,7 @@ public partial class MoreInjuriesSettings : ModSettings
 
     [SettingsEntry<float>(DefaultValue = 0.25f)]
     internal partial ref float SuctionDeviceMinimumSuccessRate { get; }
-    
+
     // lung collapse
     [SettingsEntry<bool>(DefaultValue = true)]
     internal partial ref bool EnableLungCollapse { get; }
@@ -91,7 +91,7 @@ public partial class MoreInjuriesSettings : ModSettings
 
     [SettingsEntry<float>(DefaultValue = 0.85f)]
     internal partial ref float LungCollapseMaxSeverityRoot { get; }
-    
+
     // spalling
     [SettingsEntry<bool>(DefaultValue = true)]
     internal partial ref bool EnableSpalling { get; }
@@ -101,7 +101,7 @@ public partial class MoreInjuriesSettings : ModSettings
 
     [SettingsEntry<float>(DefaultValue = 0.75f)]
     internal partial ref float SpallingChance { get; }
-    
+
     // hearing damage
     [SettingsEntry<bool>(DefaultValue = true)]
     internal partial ref bool EnableBasicHearingDamage { get; }
@@ -120,7 +120,7 @@ public partial class MoreInjuriesSettings : ModSettings
 
     [SettingsEntry<float>(DefaultValue = 0.25f)]
     internal partial ref float HearingDamagePermanentChanceFactor { get; }
-    
+
     // fractures
     [SettingsEntry<bool>(DefaultValue = true)]
     internal partial ref bool EnableFractures { get; }
@@ -142,7 +142,7 @@ public partial class MoreInjuriesSettings : ModSettings
 
     [SettingsEntry<bool>(DefaultValue = true)]
     internal partial ref bool EnableApplySplintJob { get; }
-    
+
     // hypovolemic shock, cardiac arrest, and the trauma triad of death
     [SettingsEntry<bool>(DefaultValue = true)]
     internal partial ref bool EnableHypovolemicShock { get; }
@@ -162,6 +162,9 @@ public partial class MoreInjuriesSettings : ModSettings
     [SettingsEntry<float>(DefaultValue = 0.5f)]
     internal partial ref float DefibrillatorMinimumSuccessRate { get; }
 
+    [SettingsEntry<float>(DefaultValue = 0.1f)]
+    internal partial ref float DefibrillatorBreakOnUseRate { get; }
+
     [SettingsEntry<bool>(DefaultValue = true)]
     internal partial ref bool EnableAdvancedTraumaSimulation { get; }
 
@@ -173,7 +176,7 @@ public partial class MoreInjuriesSettings : ModSettings
 
     [SettingsEntry<float>(DefaultValue = 0.05f)]
     internal partial ref float IndependentCoagulopathySalineIvSafetyThreshold { get; }
-    
+
     // neural damage and permanent brain injuries
     [SettingsEntry<bool>(DefaultValue = true)]
     internal partial ref bool EnableNeuralDamage { get; }
@@ -202,7 +205,7 @@ public partial class MoreInjuriesSettings : ModSettings
 
     [SettingsEntry<float>(DefaultValue = 0.5f)]
     internal partial ref float MinBleedRateForAutoTourniquet { get; }
-    
+
     // miscellaneous
     [SettingsEntry<bool>(DefaultValue = true)]
     internal partial ref bool EnableFireInhalation { get; }

--- a/Source/MoreInjuries/MoreInjuries/Things/ReusabilityUtility.cs
+++ b/Source/MoreInjuries/MoreInjuries/Things/ReusabilityUtility.cs
@@ -31,7 +31,7 @@ public static class ReusabilityUtility
         }
     }
 
-    public static void TryDestroyReusableIngredient(Thing ingredient, Pawn doctor, bool destroyStack = true)
+    public static void TryDestroyReusableIngredient(Thing ingredient, Pawn doctor, bool destroyStack = false)
     {
         if (ingredient.def.GetModExtension<ReusabilityProps_ModExtension>() is { DestroyChanceModifier: { } destroyChanceModifier })
         {


### PR DESCRIPTION
closes #125 

* Uses the new thing modifiers to connect a setting to the previously xml-defined value
* Stop entire stacks from being destroyed
* Fix incorrect destroyChanceModifier class name