### PR TITLE
add optional DecorateWith and MayRequire properties

### DIFF
--- a/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/Attributes/XmlBindingAttribute.cs
+++ b/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/Attributes/XmlBindingAttribute.cs
@@ -57,4 +57,16 @@ public sealed class XmlBindingAttribute(string name) : global::System.Attribute
     /// <see cref="global::System.ObsoleteAttribute"/>, allowing direct access without compiler warnings.
     /// </summary>
     public bool AllowRawAccess { get; init; }
+
+    /// <summary>
+    /// Optional parameterless attribute type to apply to the generated backing field.
+    /// The attribute must have a parameterless constructor and target fields.
+    /// </summary>
+    public global::System.Type? DecorateWith { get; init; }
+
+    /// <summary>
+    /// Optional mod package ID string. When set, the generated backing field is decorated with
+    /// <c>[global::RimWorld.MayRequireAttribute(&lt;value&gt;)]</c>.
+    /// </summary>
+    public string? MayRequire { get; init; }
 }

--- a/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/Attributes/XmlBindingAttribute`1.cs
+++ b/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/Attributes/XmlBindingAttribute`1.cs
@@ -43,4 +43,16 @@ public sealed class XmlBindingAttribute<T>(string name, T defaultValue) : global
     /// <see cref="global::System.ObsoleteAttribute"/>, allowing direct access without compiler warnings.
     /// </summary>
     public bool AllowRawAccess { get; init; }
+
+    /// <summary>
+    /// Optional parameterless attribute type to apply to the generated backing field.
+    /// The attribute must have a parameterless constructor and target fields.
+    /// </summary>
+    public global::System.Type? DecorateWith { get; init; }
+
+    /// <summary>
+    /// Optional mod package ID string. When set, the generated backing field is decorated with
+    /// <c>[global::RimWorld.MayRequireAttribute(&lt;value&gt;)]</c>.
+    /// </summary>
+    public string? MayRequire { get; init; }
 }

--- a/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/XmlBindableCandidateFactory.cs
+++ b/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/XmlBindableCandidateFactory.cs
@@ -80,6 +80,13 @@ internal static class XmlBindableCandidateFactory
                 continue;
             }
 
+            // Decorate and MayRequire (shared for both attribute variants)
+            if (!TryExtractFieldDecorations(resolvedAttribute!, typeSymbol, property, diagnostics,
+                out string? decorateAttributeDisplay, out string? mayRequire))
+            {
+                continue;
+            }
+
             if (!property.IsPartialDefinition)
             {
                 diagnostics.Add(Diagnostic.Create(
@@ -109,7 +116,7 @@ internal static class XmlBindableCandidateFactory
                     fieldName));
                 continue;
             }
-            memberModels.Add(CreateMemberModel(property, fieldName!, defaultValueExpression, defaultValueIsNullable, allowRawAccess, validateMethodName, validateIsStatic, transformMethodName, transformIsStatic));
+            memberModels.Add(CreateMemberModel(property, fieldName!, defaultValueExpression, defaultValueIsNullable, allowRawAccess, decorateAttributeDisplay, mayRequire, validateMethodName, validateIsStatic, transformMethodName, transformIsStatic));
         }
 
         string namespaceName = typeSymbol.ContainingNamespace?.IsGlobalNamespace is false
@@ -124,7 +131,7 @@ internal static class XmlBindableCandidateFactory
             diagnostics.ToImmutable());
     }
 
-    private static XmlBindingModel CreateMemberModel(IPropertySymbol property, string fieldName, string? defaultValueExpression, bool defaultValueIsNullable, bool allowRawAccess, string? validateMethodName, bool validateIsStatic, string? transformMethodName, bool transformIsStatic)
+    private static XmlBindingModel CreateMemberModel(IPropertySymbol property, string fieldName, string? defaultValueExpression, bool defaultValueIsNullable, bool allowRawAccess, string? decorateAttributeDisplay, string? mayRequire, string? validateMethodName, bool validateIsStatic, string? transformMethodName, bool transformIsStatic)
     {
         bool hasSetter = property.SetMethod is not null;
         bool isInitOnly = property.SetMethod?.IsInitOnly ?? false;
@@ -199,6 +206,8 @@ internal static class XmlBindableCandidateFactory
             FieldName: fieldName,
             DefaultValueExpression: defaultValueExpression,
             AllowRawAccess: allowRawAccess,
+            DecorateAttributeDisplay: decorateAttributeDisplay,
+            MayRequire: mayRequire,
             Setter: setter,
             GetterPipeline: getterPipeline);
     }
@@ -344,6 +353,83 @@ internal static class XmlBindableCandidateFactory
                 return false;
             }
             transformMethodName = transformName;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Extracts and validates the Decorate and MayRequire properties from any <see cref="AttributeData"/>.
+    /// Returns <see langword="false"/> if validation fails (diagnostic already emitted).
+    /// </summary>
+    private static bool TryExtractFieldDecorations(
+        AttributeData attribute,
+        INamedTypeSymbol typeSymbol,
+        IPropertySymbol property,
+        ImmutableArray<Diagnostic>.Builder diagnostics,
+        out string? decorateAttributeDisplay,
+        out string? mayRequire)
+    {
+        decorateAttributeDisplay = null;
+        mayRequire = AttributeDataReader.GetNamedStringArgument(attribute, nameof(XmlBindingAttribute.MayRequire));
+
+        INamedTypeSymbol? decorateType = AttributeDataReader.GetNamedTypeArgument(attribute, nameof(XmlBindingAttribute.DecorateWith));
+        if (decorateType is not null)
+        {
+            // Verify the type derives from System.Attribute
+            bool isAttribute = false;
+            for (INamedTypeSymbol? baseType = decorateType.BaseType; baseType is not null; baseType = baseType.BaseType)
+            {
+                if (baseType.SpecialType == SpecialType.None
+                    && baseType.ToDisplayString() == "System.Attribute")
+                {
+                    isAttribute = true;
+                    break;
+                }
+            }
+
+            // Verify the type has a parameterless constructor
+            bool hasParameterlessCtor = false;
+            if (isAttribute)
+            {
+                foreach (IMethodSymbol ctor in decorateType.InstanceConstructors)
+                {
+                    if (ctor.Parameters.IsEmpty && ctor.DeclaredAccessibility == Accessibility.Public)
+                    {
+                        hasParameterlessCtor = true;
+                        break;
+                    }
+                }
+            }
+
+            // Verify AttributeUsage allows fields
+            bool allowsFields = true;
+            if (isAttribute && hasParameterlessCtor)
+            {
+                foreach (AttributeData attr in decorateType.GetAttributes())
+                {
+                    if (attr.AttributeClass?.ToDisplayString() == "System.AttributeUsageAttribute"
+                        && attr.ConstructorArguments is [{ Value: int targets }])
+                    {
+                        // AttributeTargets.Field = 256, AttributeTargets.All = 32767
+                        allowsFields = (targets & 256) != 0;
+                        break;
+                    }
+                }
+            }
+
+            if (!isAttribute || !hasParameterlessCtor || !allowsFields)
+            {
+                diagnostics.Add(Diagnostic.Create(
+                    XmlSerializationGeneratorDiagnostics.InvalidDecorateAttribute,
+                    property.Locations.FirstOrDefault(),
+                    property.Name,
+                    typeSymbol.Name,
+                    decorateType.ToDisplayString()));
+                return false;
+            }
+
+            decorateAttributeDisplay = decorateType.ToDisplayString(FullyQualifiedFormat);
         }
 
         return true;

--- a/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/XmlBindableCandidateFactory.cs
+++ b/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/XmlBindableCandidateFactory.cs
@@ -380,8 +380,7 @@ internal static class XmlBindableCandidateFactory
             bool isAttribute = false;
             for (INamedTypeSymbol? baseType = decorateType.BaseType; baseType is not null; baseType = baseType.BaseType)
             {
-                if (baseType.SpecialType == SpecialType.None
-                    && baseType.ToDisplayString() == "System.Attribute")
+                if (baseType.SpecialType == SpecialType.None && baseType.ToDisplayString() == "System.Attribute")
                 {
                     isAttribute = true;
                     break;
@@ -411,14 +410,13 @@ internal static class XmlBindableCandidateFactory
                     if (attr.AttributeClass?.ToDisplayString() == "System.AttributeUsageAttribute"
                         && attr.ConstructorArguments is [{ Value: int targets }])
                     {
-                        // AttributeTargets.Field = 256, AttributeTargets.All = 32767
-                        allowsFields = (targets & 256) != 0;
+                        allowsFields = (targets & (int)AttributeTargets.Field) != 0;
                         break;
                     }
                 }
             }
 
-            if (!isAttribute || !hasParameterlessCtor || !allowsFields)
+            if (!isAttribute || !hasParameterlessCtor || !allowsFields || decorateType.IsAbstract)
             {
                 diagnostics.Add(Diagnostic.Create(
                     XmlSerializationGeneratorDiagnostics.InvalidDecorateAttribute,

--- a/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/XmlBindingModel.cs
+++ b/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/XmlBindingModel.cs
@@ -34,6 +34,8 @@ internal sealed record XmlBindingModel(
     string FieldName,
     string? DefaultValueExpression,
     bool AllowRawAccess,
+    string? DecorateAttributeDisplay,
+    string? MayRequire,
     SetterModel? Setter,
     GetterPipelineModel GetterPipeline
 )

--- a/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/XmlBindingsRenderer.cs
+++ b/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/XmlBindingsRenderer.cs
@@ -53,7 +53,8 @@ internal static class XmlBindingsRenderer
             }
             if (member.MayRequire is not null)
             {
-                builder.AppendLine($"[global::RimWorld.MayRequireAttribute(\"{member.MayRequire}\")]");
+                string mayRequireLiteral = SymbolDisplay.FormatLiteral(member.MayRequire, quote: true);
+                builder.AppendLine($"[global::RimWorld.MayRequireAttribute({mayRequireLiteral})]");
             }
             builder.AppendLine($"private {readonlyModifier}{member.FieldTypeDisplay} {member.FieldName} = {defaultExpression};");
         }

--- a/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/XmlBindingsRenderer.cs
+++ b/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/XmlBindingsRenderer.cs
@@ -47,6 +47,14 @@ internal static class XmlBindingsRenderer
             {
                 builder.AppendLine($"[global::{typeof(ObsoleteAttribute).FullName}(\"Do not use this field directly. Use the corresponding property instead.\", error: false)]");
             }
+            if (member.DecorateAttributeDisplay is not null)
+            {
+                builder.AppendLine($"[{member.DecorateAttributeDisplay}]");
+            }
+            if (member.MayRequire is not null)
+            {
+                builder.AppendLine($"[global::RimWorld.MayRequireAttribute(\"{member.MayRequire}\")]");
+            }
             builder.AppendLine($"private {readonlyModifier}{member.FieldTypeDisplay} {member.FieldName} = {defaultExpression};");
         }
     }

--- a/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/XmlSerializationGeneratorDiagnostics.cs
+++ b/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/XmlSerializationGeneratorDiagnostics.cs
@@ -98,7 +98,7 @@ internal static class XmlSerializationGeneratorDiagnostics
     public static DiagnosticDescriptor InvalidDecorateAttribute { get; } = new(
         id: "MIXML012",
         title: "Invalid DecorateWith attribute type",
-        messageFormat: $"Property '{{0}}' in class '{{1}}' uses an {nameof(XmlBindingAttribute)} with DecorateWith type '{{2}}' that is not a valid parameterless attribute targeting fields.",
+        messageFormat: $"Property '{{0}}' in class '{{1}}' uses an {nameof(XmlBindingAttribute)} with DecorateWith type '{{2}}' that is not a valid concrete, parameterless attribute targeting fields.",
         category: CATEGORY,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);

--- a/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/XmlSerializationGeneratorDiagnostics.cs
+++ b/Source/MoreInjuries/MoreInjuries.Roslyn.SourceGen/XmlBinding/XmlSerializationGeneratorDiagnostics.cs
@@ -94,4 +94,12 @@ internal static class XmlSerializationGeneratorDiagnostics
         category: CATEGORY,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    public static DiagnosticDescriptor InvalidDecorateAttribute { get; } = new(
+        id: "MIXML012",
+        title: "Invalid DecorateWith attribute type",
+        messageFormat: $"Property '{{0}}' in class '{{1}}' uses an {nameof(XmlBindingAttribute)} with DecorateWith type '{{2}}' that is not a valid parameterless attribute targeting fields.",
+        category: CATEGORY,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }


### PR DESCRIPTION
This pull request adds support for decorating generated backing fields with custom attributes and the `MayRequire` attribute in the XML binding source generator. It introduces new properties to the `XmlBindingAttribute` classes, updates the code generation pipeline to handle these options, and ensures proper validation and diagnostics for invalid usage.

**Attribute Decoration Support:**

* Added `DecorateWith` and `MayRequire` properties to both `XmlBindingAttribute` and `XmlBindingAttribute<T>`, allowing users to specify a custom attribute type and an optional mod package ID for generated fields. [[1]](diffhunk://#diff-786f95781399a44aa7dd91ee8278527a8160ea838f0b98dccad7cf9ad7765312R60-R71) [[2]](diffhunk://#diff-25314e640318e998d649d3cd4a0c49e8e7be8929bfc5f53094d9491209e4ba99R46-R57)
* Implemented extraction and validation logic for these new properties in `XmlBindableCandidateFactory`, including checks for attribute type validity, parameterless constructor, and correct `AttributeTargets`. [[1]](diffhunk://#diff-b136334ceff4bc0c8eb0901fdd12afc0aaa7975a55bc5d6715748464742090f4R83-R89) [[2]](diffhunk://#diff-b136334ceff4bc0c8eb0901fdd12afc0aaa7975a55bc5d6715748464742090f4R360-R436)
* Updated the `XmlBindingModel` record and the code generation pipeline to store and use the new decoration information. [[1]](diffhunk://#diff-b763caf0a9a9262c0a3eda58063e20dc1cf95c58ec908000e070ae800913c9d8R37-R38) [[2]](diffhunk://#diff-b136334ceff4bc0c8eb0901fdd12afc0aaa7975a55bc5d6715748464742090f4L112-R119) [[3]](diffhunk://#diff-b136334ceff4bc0c8eb0901fdd12afc0aaa7975a55bc5d6715748464742090f4L127-R134) [[4]](diffhunk://#diff-b136334ceff4bc0c8eb0901fdd12afc0aaa7975a55bc5d6715748464742090f4R209-R210)

**Code Generation Enhancements:**

* Modified the field generation logic in `XmlBindingsRenderer` to emit the specified custom attribute and the `MayRequire` attribute on generated fields when requested.

**Diagnostics:**

* Added a new diagnostic (`MIXML012`) to report invalid usages of the `DecorateWith` property, such as specifying a type that is not a valid parameterless attribute targeting fields.