### PR TITLE
add workflow permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,7 +8,8 @@ on:
     branches: [ "main", "rc-*" ]
   pull_request:
     branches: [ "main", "rc-*" ]
-
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/markdown-links-verifier.yml
+++ b/.github/workflows/markdown-links-verifier.yml
@@ -4,7 +4,8 @@ on:
     branches: [ "main", "rc-*" ]
   pull_request:
     branches: [ "main", "rc-*" ]
-
+permissions:
+  contents: read
 jobs:
   validate_links:
     name: Markdown links verifier


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration files to explicitly set minimal permissions for workflow runs. This helps improve the security posture of the CI pipelines by ensuring that workflows only have read access to repository contents.

Security improvements in workflow configuration:

* Added `permissions: contents: read` to `.github/workflows/dotnet.yml` to restrict workflow permissions to read-only access for repository contents.
* Added `permissions: contents: read` to `.github/workflows/markdown-links-verifier.yml` to restrict workflow permissions to read-only access for repository contents.