### PR TITLE
Pr/gene immunity severity patch

### DIFF
--- a/Defs/HediffDefs/Hediffs_Choking.xml
+++ b/Defs/HediffDefs/Hediffs_Choking.xml
@@ -11,7 +11,7 @@
       <li Class="MoreInjuries.HealthConditions.Secondary.HediffModifier_SeverityModifiers_ModExtension">
         <modifiers>
           <li MayRequire="Ludeon.RimWorld.Biotech">
-            <mode>OnIncrease</mode>
+            <apply>OnIncrease</apply>
             <modifier Class="MoreInjuries.HealthConditions.Secondary.Handlers.Modifiers.HediffModifier_Genes_WhenPresent">
               <geneModifiers>
                 <li>
@@ -141,7 +141,7 @@
       <li Class="MoreInjuries.HealthConditions.Secondary.HediffModifier_SeverityModifiers_ModExtension">
         <modifiers>
           <li MayRequire="Ludeon.RimWorld.Biotech">
-            <mode>Always</mode>
+            <apply>OnIncrease</apply>
             <modifier Class="MoreInjuries.HealthConditions.Secondary.Handlers.Modifiers.HediffModifier_Genes_WhenPresent">
               <geneModifiers>
                 <li>

--- a/Defs/HediffDefs/Hediffs_Choking.xml
+++ b/Defs/HediffDefs/Hediffs_Choking.xml
@@ -10,13 +10,16 @@
     <modExtensions>
       <li Class="MoreInjuries.HealthConditions.Secondary.HediffModifier_SeverityModifiers_ModExtension">
         <modifiers>
-          <li MayRequire="Ludeon.RimWorld.Biotech" Class="MoreInjuries.HealthConditions.Secondary.Handlers.Modifiers.HediffModifier_Genes_WhenPresent">
-            <geneModifiers>
-              <li>
-                <geneDef>VacuumResistance_Total</geneDef>
-                <modifier>0.05</modifier>
-              </li>
-            </geneModifiers>
+          <li MayRequire="Ludeon.RimWorld.Biotech">
+            <mode>OnIncrease</mode>
+            <modifier Class="MoreInjuries.HealthConditions.Secondary.Handlers.Modifiers.HediffModifier_Genes_WhenPresent">
+              <geneModifiers>
+                <li>
+                  <geneDef>VacuumResistance_Total</geneDef>
+                  <modifier>0.05</modifier>
+                </li>
+              </geneModifiers>
+            </modifier>
           </li>
         </modifiers>
       </li>
@@ -137,13 +140,16 @@
     <modExtensions>
       <li Class="MoreInjuries.HealthConditions.Secondary.HediffModifier_SeverityModifiers_ModExtension">
         <modifiers>
-          <li MayRequire="Ludeon.RimWorld.Biotech" Class="MoreInjuries.HealthConditions.Secondary.Handlers.Modifiers.HediffModifier_Genes_WhenPresent">
-            <geneModifiers>
-              <li>
-                <geneDef>VacuumResistance_Total</geneDef>
-                <modifier>0.05</modifier>
-              </li>
-            </geneModifiers>
+          <li MayRequire="Ludeon.RimWorld.Biotech">
+            <mode>Always</mode>
+            <modifier Class="MoreInjuries.HealthConditions.Secondary.Handlers.Modifiers.HediffModifier_Genes_WhenPresent">
+              <geneModifiers>
+                <li>
+                  <geneDef>VacuumResistance_Total</geneDef>
+                  <modifier>0.05</modifier>
+                </li>
+              </geneModifiers>
+            </modifier>
           </li>
         </modifiers>
       </li>

--- a/Defs/HediffDefs/Hediffs_Ischemia.xml
+++ b/Defs/HediffDefs/Hediffs_Ischemia.xml
@@ -16,13 +16,16 @@
     <modExtensions>
       <li Class="MoreInjuries.HealthConditions.Secondary.HediffModifier_SeverityModifiers_ModExtension">
         <modifiers>
-          <li MayRequire="Ludeon.RimWorld.Biotech" Class="MoreInjuries.HealthConditions.Secondary.Handlers.Modifiers.HediffModifier_Genes_WhenPresent">
-            <geneModifiers>
-              <li>
-                <geneDef>VacuumResistance_Total</geneDef>
-                <modifier>0.05</modifier>
-              </li>
-            </geneModifiers>
+          <li MayRequire="Ludeon.RimWorld.Biotech">
+            <mode>Always</mode>
+            <modifier Class="MoreInjuries.HealthConditions.Secondary.Handlers.Modifiers.HediffModifier_Genes_WhenPresent">
+              <geneModifiers>
+                <li>
+                  <geneDef>VacuumResistance_Total</geneDef>
+                  <modifier>0.05</modifier>
+                </li>
+              </geneModifiers>
+            </modifier>
           </li>
         </modifiers>
       </li>

--- a/Defs/HediffDefs/Hediffs_Ischemia.xml
+++ b/Defs/HediffDefs/Hediffs_Ischemia.xml
@@ -17,7 +17,7 @@
       <li Class="MoreInjuries.HealthConditions.Secondary.HediffModifier_SeverityModifiers_ModExtension">
         <modifiers>
           <li MayRequire="Ludeon.RimWorld.Biotech">
-            <mode>Always</mode>
+            <apply>OnIncrease</apply>
             <modifier Class="MoreInjuries.HealthConditions.Secondary.Handlers.Modifiers.HediffModifier_Genes_WhenPresent">
               <geneModifiers>
                 <li>

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/Choking/HediffComp_Choking.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/Choking/HediffComp_Choking.cs
@@ -109,11 +109,11 @@ public sealed class HediffComp_Choking : HediffComp, IHediffCompHandler
         {
             decrease = 0.025f;
         }
+        float change = Rand.Range(-decrease, increase);
         if (parent.def.GetModExtension<HediffModifier_SeverityModifiers_ModExtension>() is { } downstream)
         {
-            increase *= downstream.GetModifier(parent, this);
+            change = downstream.ApplyTo(change, parent, this);
         }
-        float change = Rand.Range(-decrease, increase);
         bool coughing = IsCoughing(source, patient);
         if (coughing)
         {

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/HediffComp_SeverityPerDay_WithModifiers.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/HediffComp_SeverityPerDay_WithModifiers.cs
@@ -11,7 +11,7 @@ public class HediffComp_SeverityPerDay_WithModifiers : HediffComp_SeverityPerDay
         float baseSeverityChange = base.SeverityChangePerDay();
         if (parent.def.GetModExtension<HediffModifier_SeverityModifiers_ModExtension>() is { } downstream)
         {
-            baseSeverityChange *= downstream.GetModifier(parent, this);
+            baseSeverityChange = downstream.ApplyTo(baseSeverityChange, parent, this);
         }
         return baseSeverityChange;
     }

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/Secondary/HediffModifier_SeverityModifiers_ModExtension.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/Secondary/HediffModifier_SeverityModifiers_ModExtension.cs
@@ -1,3 +1,30 @@
-﻿namespace MoreInjuries.HealthConditions.Secondary;
+﻿using MoreInjuries.HealthConditions.Secondary.Handlers;
+using MoreInjuries.Roslyn.SourceGen.XmlBinding.Attributes;
+using System.Collections.Generic;
+using Verse;
 
-public sealed class HediffModifier_SeverityModifiers_ModExtension : HediffModifier_ModifiersComposite_ModExtension;
+namespace MoreInjuries.HealthConditions.Secondary;
+
+/// <summary>
+/// A <see cref="DefModExtension"/> attached to a <see cref="HediffDef"/> that lists severity modifiers,
+/// each of which specifies how it should be applied to the current severity change
+/// (see <see cref="SeverityModifierApplication"/>).
+/// </summary>
+[XmlBindable]
+public sealed partial class HediffModifier_SeverityModifiers_ModExtension : DefModExtension
+{
+    [XmlBinding("modifiers")]
+    public partial IReadOnlyList<SeverityModifierEntry> Modifiers { get; }
+
+    /// <summary>
+    /// Applies all configured modifiers to <paramref name="currentChange"/> in order and returns the result.
+    /// </summary>
+    public float ApplyTo(float currentChange, Hediff hediff, IHediffCompHandler compHandler)
+    {
+        foreach (SeverityModifierEntry entry in Modifiers)
+        {
+            currentChange = entry.ApplyTo(currentChange, hediff, compHandler);
+        }
+        return currentChange;
+    }
+}

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/Secondary/SeverityModifierApplication.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/Secondary/SeverityModifierApplication.cs
@@ -1,4 +1,4 @@
-namespace MoreInjuries.HealthConditions.Secondary;
+﻿namespace MoreInjuries.HealthConditions.Secondary;
 
 /// <summary>
 /// Determines how a <see cref="Handlers.Modifiers.SecondaryHediffModifier"/>'s factor is applied to the
@@ -7,7 +7,7 @@ namespace MoreInjuries.HealthConditions.Secondary;
 public enum SeverityModifierApplication
 {
     /// <summary>Always multiply the current severity change by the factor.</summary>
-    Always,
+    OnChange,
 
     /// <summary>Multiply the current severity change by the factor only when it is positive.</summary>
     OnIncrease,
@@ -16,8 +16,8 @@ public enum SeverityModifierApplication
     OnDecrease,
 
     /// <summary>Skew the current severity change upwards by adding <c>factor * abs(currentChange)</c>.</summary>
-    IncreaseSkew,
+    SkewedIncrease,
 
     /// <summary>Skew the current severity change downwards by subtracting <c>factor * abs(currentChange)</c>.</summary>
-    DecreaseSkew,
+    SkewedDecrease,
 }

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/Secondary/SeverityModifierApplication.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/Secondary/SeverityModifierApplication.cs
@@ -1,0 +1,23 @@
+namespace MoreInjuries.HealthConditions.Secondary;
+
+/// <summary>
+/// Determines how a <see cref="Handlers.Modifiers.SecondaryHediffModifier"/>'s factor is applied to the
+/// current severity change inside <see cref="HediffModifier_SeverityModifiers_ModExtension"/>.
+/// </summary>
+public enum SeverityModifierApplication
+{
+    /// <summary>Always multiply the current severity change by the factor.</summary>
+    Always,
+
+    /// <summary>Multiply the current severity change by the factor only when it is positive.</summary>
+    OnIncrease,
+
+    /// <summary>Multiply the current severity change by the factor only when it is negative.</summary>
+    OnDecrease,
+
+    /// <summary>Skew the current severity change upwards by adding <c>factor * abs(currentChange)</c>.</summary>
+    IncreaseSkew,
+
+    /// <summary>Skew the current severity change downwards by subtracting <c>factor * abs(currentChange)</c>.</summary>
+    DecreaseSkew,
+}

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/Secondary/SeverityModifierEntry.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/Secondary/SeverityModifierEntry.cs
@@ -1,0 +1,39 @@
+using MoreInjuries.HealthConditions.Secondary.Handlers;
+using MoreInjuries.HealthConditions.Secondary.Handlers.Modifiers;
+using MoreInjuries.Roslyn.SourceGen.XmlBinding.Attributes;
+using System;
+using Verse;
+
+namespace MoreInjuries.HealthConditions.Secondary;
+
+/// <summary>
+/// A single entry in <see cref="HediffModifier_SeverityModifiers_ModExtension.Modifiers"/>: pairs a
+/// <see cref="SecondaryHediffModifier"/> with an application <see cref="Mode"/> that controls how its
+/// factor is combined with the current severity change.
+/// </summary>
+[XmlBindable]
+public sealed partial class SeverityModifierEntry
+{
+    [XmlBinding<SeverityModifierApplication>("mode", SeverityModifierApplication.Always)]
+    public partial SeverityModifierApplication Mode { get; }
+
+    [XmlBinding("modifier")]
+    public partial SecondaryHediffModifier Modifier { get; }
+
+    /// <summary>
+    /// Applies this entry's modifier to <paramref name="currentChange"/> according to <see cref="Mode"/>.
+    /// </summary>
+    public float ApplyTo(float currentChange, Hediff hediff, IHediffCompHandler compHandler)
+    {
+        float factor = Modifier.GetModifier(hediff, compHandler);
+        return Mode switch
+        {
+            SeverityModifierApplication.Always => currentChange * factor,
+            SeverityModifierApplication.OnIncrease => currentChange > 0f ? currentChange * factor : currentChange,
+            SeverityModifierApplication.OnDecrease => currentChange < 0f ? currentChange * factor : currentChange,
+            SeverityModifierApplication.IncreaseSkew => currentChange + factor * Math.Abs(currentChange),
+            SeverityModifierApplication.DecreaseSkew => currentChange - factor * Math.Abs(currentChange),
+            _ => currentChange,
+        };
+    }
+}

--- a/Source/MoreInjuries/MoreInjuries/HealthConditions/Secondary/SeverityModifierEntry.cs
+++ b/Source/MoreInjuries/MoreInjuries/HealthConditions/Secondary/SeverityModifierEntry.cs
@@ -1,38 +1,37 @@
-using MoreInjuries.HealthConditions.Secondary.Handlers;
+﻿using MoreInjuries.HealthConditions.Secondary.Handlers;
 using MoreInjuries.HealthConditions.Secondary.Handlers.Modifiers;
 using MoreInjuries.Roslyn.SourceGen.XmlBinding.Attributes;
-using System;
 using Verse;
 
 namespace MoreInjuries.HealthConditions.Secondary;
 
 /// <summary>
 /// A single entry in <see cref="HediffModifier_SeverityModifiers_ModExtension.Modifiers"/>: pairs a
-/// <see cref="SecondaryHediffModifier"/> with an application <see cref="Mode"/> that controls how its
+/// <see cref="SecondaryHediffModifier"/> with an <see cref="Apply"/> mode that controls how its
 /// factor is combined with the current severity change.
 /// </summary>
 [XmlBindable]
 public sealed partial class SeverityModifierEntry
 {
-    [XmlBinding<SeverityModifierApplication>("mode", SeverityModifierApplication.Always)]
-    public partial SeverityModifierApplication Mode { get; }
+    [XmlBinding("apply", NullableBackingField = true)]
+    public partial SeverityModifierApplication Apply { get; }
 
     [XmlBinding("modifier")]
     public partial SecondaryHediffModifier Modifier { get; }
 
     /// <summary>
-    /// Applies this entry's modifier to <paramref name="currentChange"/> according to <see cref="Mode"/>.
+    /// Applies this entry's modifier to <paramref name="currentChange"/> according to <see cref="Apply"/>.
     /// </summary>
     public float ApplyTo(float currentChange, Hediff hediff, IHediffCompHandler compHandler)
     {
         float factor = Modifier.GetModifier(hediff, compHandler);
-        return Mode switch
+        return (Apply, currentChange) switch
         {
-            SeverityModifierApplication.Always => currentChange * factor,
-            SeverityModifierApplication.OnIncrease => currentChange > 0f ? currentChange * factor : currentChange,
-            SeverityModifierApplication.OnDecrease => currentChange < 0f ? currentChange * factor : currentChange,
-            SeverityModifierApplication.IncreaseSkew => currentChange + factor * Math.Abs(currentChange),
-            SeverityModifierApplication.DecreaseSkew => currentChange - factor * Math.Abs(currentChange),
+            (SeverityModifierApplication.OnChange, _) => currentChange * factor,
+            (SeverityModifierApplication.OnIncrease, > 0f) => currentChange * factor,
+            (SeverityModifierApplication.OnDecrease, < 0f) => currentChange * factor,
+            (SeverityModifierApplication.SkewedIncrease, _) => currentChange + (factor * Math.Abs(currentChange)),
+            (SeverityModifierApplication.SkewedDecrease, _) => currentChange - (factor * Math.Abs(currentChange)),
             _ => currentChange,
         };
     }


### PR DESCRIPTION
This pull request introduces a new, more flexible system for applying severity modifiers to health conditions. The changes replace the previous approach with a composable, order-dependent modifier pipeline that allows each modifier to specify how it should be applied (e.g., only on increases, decreases, or always). This is achieved through new data structures and XML schema changes, as well as refactoring the relevant code to use the new system.

**Core system refactor and extensibility:**

* Introduced the `SeverityModifierApplication` enum to allow each modifier to specify when and how it should be applied to severity changes (e.g., only on increase, decrease, always, or skewed).
* Added the `SeverityModifierEntry` class, which pairs a modifier with an application mode and provides logic to apply the modifier accordingly.
* Refactored `HediffModifier_SeverityModifiers_ModExtension` to use a list of `SeverityModifierEntry` objects, applying them sequentially to severity changes via a new `ApplyTo` method.

**Integration into health condition logic:**

* Updated `HediffComp_Choking.cs` and `HediffComp_SeverityPerDay_WithModifiers.cs` to use the new `ApplyTo` method for applying severity modifiers, replacing the old multiplicative approach. [[1]](diffhunk://#diff-9d2ef943ea128d4657071da8b2693aa5e693e46730ceba9e6b99a7787fa00ad4R112-L116) [[2]](diffhunk://#diff-961716e96ee886d2c0fcfb6fe84f0173614ea8c15069a2f741c4ef078f9cd1a3L14-R14)

**XML schema and data updates:**

* Modified the XML definitions for choking and ischemia hediffs to use the new structure, allowing specification of the `apply` mode for each modifier and wrapping modifiers in the new format. [[1]](diffhunk://#diff-3554a23bb143e12fab897e7ef0a82c329bc1d4eeb6386fe28f193a4cfdaa8c8bL13-R22) [[2]](diffhunk://#diff-3554a23bb143e12fab897e7ef0a82c329bc1d4eeb6386fe28f193a4cfdaa8c8bL140-R152) [[3]](diffhunk://#diff-db0bd28a3375b6c990b38e30342ab9e62e8408477b0a9fcc6b8c6641183014ecL19-R28)