### PR TITLE
fix: keep saline bags craftable when DBH Thirst need is disabled

### DIFF
--- a/Source/MoreInjuries/MoreInjuries/Initialization/RecipeIngredientPruner.cs
+++ b/Source/MoreInjuries/MoreInjuries/Initialization/RecipeIngredientPruner.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Linq;
+using Verse;
+
+namespace MoreInjuries.Initialization;
+
+/// <summary>
+/// Helpers for removing ingredients from a <see cref="RecipeDef"/> at load time when the thing they
+/// require cannot be produced in the current mod configuration (for example, a Dubs Bad Hygiene water
+/// bottle when the Thirst need is disabled). Kept free of any third-party-mod types so the logic can be
+/// compiled and unit-tested in every build configuration, while the conditional gating that decides
+/// <em>when</em> to call it lives in the mod-specific integration code.
+/// </summary>
+internal static class RecipeIngredientPruner
+{
+    /// <summary>
+    /// Removes every ingredient line of <paramref name="recipe"/> whose filter resolves to nothing but
+    /// the given <paramref name="thingDef"/>, and drops that def from the recipe's fixed and default
+    /// ingredient filters. Ingredient lines that also accept other things (for example a line that allows
+    /// any stone block) are left untouched. The method is idempotent: running it again after the def has
+    /// already been removed is a no-op.
+    /// </summary>
+    /// <returns><see langword="true"/> if anything was changed, otherwise <see langword="false"/>.</returns>
+    public static bool RemoveIngredient(RecipeDef recipe, ThingDef thingDef)
+    {
+        if (recipe is null || thingDef is null)
+        {
+            return false;
+        }
+
+        bool changed = false;
+
+        if (recipe.ingredients is { } ingredients)
+        {
+            // Iterate over a snapshot so we can mutate the backing list while deciding what to drop.
+            foreach (IngredientCount ingredient in ingredients.ToList())
+            {
+                if (ResolvesOnlyTo(ingredient, thingDef))
+                {
+                    ingredients.Remove(ingredient);
+                    changed = true;
+                }
+            }
+        }
+
+        changed |= Disallow(recipe.fixedIngredientFilter, thingDef);
+        changed |= Disallow(recipe.defaultIngredientFilter, thingDef);
+
+        return changed;
+    }
+
+    private static bool ResolvesOnlyTo(IngredientCount? ingredient, ThingDef thingDef)
+    {
+        if (ingredient?.filter is not { } filter)
+        {
+            return false;
+        }
+
+        List<ThingDef> allowed = filter.AllowedThingDefs?.ToList() ?? [];
+        // Only drop the line if it exists solely to require the target def. A line that also accepts other
+        // things (a category such as StoneBlocks, or a multi-thing filter) must survive so the recipe keeps
+        // its remaining ingredients.
+        return allowed.Count > 0 && allowed.All(def => def == thingDef);
+    }
+
+    private static bool Disallow(ThingFilter? filter, ThingDef thingDef)
+    {
+        if (filter is null || !filter.Allows(thingDef))
+        {
+            return false;
+        }
+
+        filter.SetAllow(thingDef, false);
+        return true;
+    }
+}

--- a/Source/MoreInjuries/MoreInjuries/Integrations/DubsBadHygiene/SalineBagRecipeWater_Initializer.cs
+++ b/Source/MoreInjuries/MoreInjuries/Integrations/DubsBadHygiene/SalineBagRecipeWater_Initializer.cs
@@ -1,0 +1,81 @@
+using DubsBadHygiene;
+using MoreInjuries.Initialization;
+using MoreInjuries.Logging;
+using System;
+using Verse;
+
+namespace MoreInjuries.Integrations.DubsBadHygiene;
+
+/// <summary>
+/// When Dubs Bad Hygiene is installed, the saline bag recipes require a <c>DBH_WaterBottle</c> ingredient
+/// (added via <c>MayRequire</c> in <c>Defs/RecipeDefs/Things/Medicine_SalineBag.xml</c>). Dubs Bad Hygiene
+/// ships with its Thirst need disabled by default, and when Thirst is off the game cannot produce water
+/// bottles, so the recipes become permanently uncraftable. This initializer detects that configuration at
+/// load time and removes the water bottle ingredient so the saline bags can still be crafted from stone
+/// blocks alone. See https://github.com/frederik-hoeft/rimworld-more-injuries/issues/150.
+/// </summary>
+[StaticConstructorOnStartup]
+public static class SalineBagRecipeWater_Initializer
+{
+    private const string WaterBottleDefName = "DBH_WaterBottle";
+
+    private static readonly string[] s_salineBagRecipeDefNames =
+    [
+        "Make_SalineBag",
+        "Make_SalineBagFive",
+    ];
+
+    static SalineBagRecipeWater_Initializer()
+    {
+        if (!ModsConfig.IsActive(SupportedMods.DUBS_BAD_HYGIENE))
+        {
+            // The integration assembly is compiled in, but Dubs Bad Hygiene is not actually active in this
+            // playthrough. The recipes carry no DBH_WaterBottle ingredient (it is added via MayRequire), so
+            // there is nothing to prune.
+            return;
+        }
+
+        if (IsThirstNeedEnabled())
+        {
+            // Thirst is active, so water bottles can be produced and the recipes are craftable as authored.
+            return;
+        }
+
+        if (DefDatabase<ThingDef>.GetNamedSilentFail(WaterBottleDefName) is not { } waterBottle)
+        {
+            return;
+        }
+
+        foreach (string recipeDefName in s_salineBagRecipeDefNames)
+        {
+            if (DefDatabase<RecipeDef>.GetNamedSilentFail(recipeDefName) is not { } recipe)
+            {
+                continue;
+            }
+
+            if (RecipeIngredientPruner.RemoveIngredient(recipe, waterBottle))
+            {
+                Logger.Log($"Removed '{WaterBottleDefName}' from recipe '{recipeDefName}' because the Dubs Bad Hygiene Thirst need is disabled.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads the Dubs Bad Hygiene Thirst setting. Returns <see langword="true"/> (leave the recipes
+    /// untouched) if the setting cannot be read, so that any future change to Dubs Bad Hygiene's settings
+    /// API degrades to the unmodified, vanilla-compatible behaviour instead of silently breaking the recipe.
+    /// </summary>
+    private static bool IsThirstNeedEnabled()
+    {
+        try
+        {
+            Settings settings = LoadedModManager.GetMod<DubsBadHygieneMod>().GetSettings<Settings>();
+            return settings.ThirstNeed;
+        }
+        catch (Exception exception)
+        {
+            Logger.Warning($"Could not read the Dubs Bad Hygiene Thirst setting; leaving saline bag recipes unchanged. ({exception.Message})");
+            return true;
+        }
+    }
+}

--- a/Source/MoreInjuries/MoreInjuries/Integrations/SupportedMods.cs
+++ b/Source/MoreInjuries/MoreInjuries/Integrations/SupportedMods.cs
@@ -3,4 +3,5 @@
 internal static class SupportedMods
 {
     public const string COMBAT_EXTENDED = "CETeam.CombatExtended";
+    public const string DUBS_BAD_HYGIENE = "Dubwise.DubsBadHygiene";
 }


### PR DESCRIPTION
## Summary

When Dubs Bad Hygiene (DBH) is installed, the saline IV bag recipes (`Make_SalineBag` and `Make_SalineBagFive`) require a `DBH_WaterBottle` ingredient, added via `MayRequire="Dubwise.DubsBadHygiene"` in `Defs/RecipeDefs/Things/Medicine_SalineBag.xml`. DBH ships with its Thirst need disabled by default, and when Thirst is off the game cannot produce water bottles at all, so both recipes become permanently uncraftable for the default DBH configuration.

This adds a load-time fix that detects the disabled-Thirst case and drops the water bottle ingredient so saline bags stay craftable from stone blocks alone.

## Why this matters

This is the bug reported in #150: with DBH installed and Thirst left at its default (off), there is no way to craft saline bags, which removes a core piece of the mod's content for a very common mod combination. The fix restores craftability without requiring the player to enable a DBH need they did not ask for.

## Changes

- `Integrations/SupportedMods.cs`: add the `DUBS_BAD_HYGIENE` package-id constant, alongside the existing `COMBAT_EXTENDED` one.
- `Initialization/RecipeIngredientPruner.cs` (new): a small, mod-agnostic helper that removes an ingredient line from a `RecipeDef` when that line resolves to nothing but a given `ThingDef`, and disallows the def from the recipe's `fixedIngredientFilter` / `defaultIngredientFilter`. It deliberately leaves multi-thing or category lines (such as the `StoneBlocks` ingredient) untouched and is idempotent. It references only base-game types so it builds in every configuration.
- `Integrations/DubsBadHygiene/SalineBagRecipeWater_Initializer.cs` (new): a `[StaticConstructorOnStartup]` initializer mirroring the existing `FixMisplacedBionics_Initializer` pattern. It no-ops unless DBH is active, reads the DBH `ThirstNeed` setting, and when Thirst is disabled removes `DBH_WaterBottle` from the two saline recipes via the helper above. Reading the setting is wrapped so that any future change to DBH's settings API degrades to leaving the recipes unchanged (vanilla-safe).

The DBH integration code is gated the same way the rest of the integration is: it only compiles in the `Debug-FullFeatureSet` configuration (which references `BadHygiene.dll`). The pruning logic and the package-id constant live outside that gate so they build in `Release` / `Test`.

A note on approach: #150 discussed both a load-time recipe scan and a more general XML-backed conditional-ingredient mechanism. This PR takes the load-time approach but keeps it targeted (it only touches the two named saline recipes and only removes the one def that cannot be produced), so it does not blindly scan every recipe in the game. Happy to rework it toward the more declarative direction if you would prefer that.

## Testing

- `RecipeIngredientPruner.cs` was compiled against the RimWorld 1.6 reference assemblies (`Krafs.Rimworld.Ref`) in `net472` to confirm the `RecipeDef` / `IngredientCount` / `ThingFilter` API usage; it builds clean. The initializer was likewise compiled against the reference assemblies with the DBH types stubbed.
- I was not able to run the mod against a live DBH install, so the `DubsBadHygiene.Settings.ThirstNeed` read path has not been exercised in-game. The setting read is guarded so that if it ever fails to resolve, the recipes are left exactly as authored. A quick check on a save with DBH installed and Thirst disabled (saline bags craftable from stone blocks, no water required) would be the most valuable confirmation.
- Note: the existing test project references only the reference assemblies, which cannot be loaded at runtime, so the suite avoids constructing base-game `Def` objects. I kept the pruning logic free of DBH types and structured for testability, but did not add a test that instantiates `RecipeDef` / `ThingFilter`, since that would not run under the current harness.

Fixes #150
